### PR TITLE
querier.parallelise-shardable-queries lib support

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -131,7 +131,7 @@
       // Don't query ingesters for older queries.
       // Chunks are 6hrs right now.  Add some slack for safety although not too much
       // if sharded queries are enabled because they only shard non ingester queries.
-      'querier.query-ingesters-within': if self.sharded_queries_enabled then '6h15m' else '12h',
+      'querier.query-ingesters-within': if $._config.sharded_queries_enabled then '6h15m' else '12h',
 
       'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -56,7 +56,7 @@
 
     ingestion_rate_global_limit_enabled: false,
 
-    sharded_queries_enabled: true,
+    sharded_queries_enabled: false,
 
     // The query-tee is an optional service which can be used to send
     // the same input query to multiple backends and make them compete

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -1,10 +1,6 @@
 {
   local container = $.core.v1.container,
 
-  querier_params:: {
-    replicas: if $._config.sharded_queries_enabled then 12 else 6,
-  },
-
   querier_args::
     $._config.ringConfig +
     $._config.storeConfig +
@@ -19,10 +15,10 @@
       'server.http-write-timeout': '1m',
 
       // Limit query concurrency to prevent multi large queries causing an OOM.
-      'querier.max-concurrent': $._config.querierConcurrency,
+      'querier.max-concurrent': $._config.querier.concurrency,
 
       // Limit to N/2 worker threads per frontend, as we have two frontends.
-      'querier.worker-parallelism': $._config.querierConcurrency / $.query_frontend_params.replicas,
+      'querier.worker-parallelism': $._config.querier.concurrency / $._config.queryFrontend.replicas,
       'querier.frontend-address': 'query-frontend.%(namespace)s.svc.cluster.local:9095' % $._config,
       'querier.frontend-client.grpc-max-send-msg-size': 100 << 20,
 
@@ -40,20 +36,20 @@
     container.withPorts($.querier_ports) +
     container.withArgsMixin($.util.mapToFlags($.querier_args)) +
     $.jaeger_mixin +
-  container.withEnvMap($.querier_env_map) +
-  if $._config.sharded_queries_enabled then
-  $.util.resourcesRequests('3', '12Gi') +
-  $.util.resourcesLimits(null, '24Gi')
-  else
-  $.util.resourcesRequests('1', '12Gi') +
-  $.util.resourcesLimits(null, '24Gi'),
+    container.withEnvMap($.querier_env_map) +
+    if $._config.queryFrontend.sharded_queries_enabled then
+    $.util.resourcesRequests('3', '12Gi') +
+    $.util.resourcesLimits(null, '24Gi')
+    else
+    $.util.resourcesRequests('1', '12Gi') +
+    $.util.resourcesLimits(null, '24Gi'),
 
   local deployment = $.apps.v1beta1.deployment,
 
   querier_deployment_labels: {},
 
   querier_deployment:
-    deployment.new('querier', $.querier_params.replicas, [$.querier_container], $.querier_deployment_labels) +
+    deployment.new('querier', $._config.querier.replicas, [$.querier_container], $.querier_deployment_labels) +
     $.util.antiAffinity +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.storage_config_mixin,

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -53,7 +53,7 @@
   querier_deployment_labels: {},
 
   querier_deployment:
-    deployment.new('querier', 3, [$.querier_container], $.querier_deployment_labels) +
+    deployment.new('querier', $.querier_params.replicas, [$.querier_container], $.querier_deployment_labels) +
     $.util.antiAffinity +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.storage_config_mixin,

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -14,7 +14,7 @@
     // (i.e. 30d) with a high split factor (i.e. 5) would result in
     // (day_splits * shard_factor * split_factor) or 30 * 16 * 5 = 2400 sharded queries, which may be
     // more than the max queue size and thus would always error.
-    query_split_factor:: 6,
+    query_split_factor:: 3,
   },
 
   query_frontend_args:: {
@@ -56,10 +56,8 @@
 
     // in process tenant queues on frontends. We divide by the number of frontends; 2 in this case in order to apply the global limit in aggregate.
     // basically base * shard_factor * query_split_factor / num_frontends where
-    'querier.max-outstanding-requests-per-tenant': std.floor(200 * self.query_frontend_params.shard_factor * self.query_frontend_params.query_split_factor / self.query_frontend_params.replicas),
+    'querier.max-outstanding-requests-per-tenant': std.floor(200 * $.query_frontend_params.shard_factor * $.query_frontend_params.query_split_factor / $.query_frontend_params.replicas),
 
-    // per request parallelism factor passed to doRequests -- not a good solution.
-    'querier.max-query-parallelism': 14 * self.query_frontend_params.shard_factor,
     'querier.query-ingesters-within': $._config.queryConfig['querier.query-ingesters-within'],
   } + $._config.storageConfig
   else {},

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -1,21 +1,5 @@
 {
   local container = $.core.v1.container,
-  local deployment = $.apps.v1beta1.deployment,
-  local service = $.core.v1.service,
-
-  query_frontend_params:: {
-    replicas: 2, // number of frontends to run
-    shard_factor: 16,  // v10 schema shard factor
-
-    // Queries can technically be sharded an arbitrary number of times. Thus query_split_factor is used
-    // as a coefficient to multiply the frontend tenant queues by. The idea is that this
-    // yields a bit of headroom so tenant queues aren't underprovisioned. Therefore the split factor
-    // should be represent the highest reasonable split factor for a query. If too low, a long query
-    // (i.e. 30d) with a high split factor (i.e. 5) would result in
-    // (day_splits * shard_factor * split_factor) or 30 * 16 * 5 = 2400 sharded queries, which may be
-    // more than the max queue size and thus would always error.
-    query_split_factor:: 3,
-  },
 
   query_frontend_args:: {
     target: 'query-frontend',
@@ -51,12 +35,12 @@
     // Limit queries to 500 days, allow this to be override per-user.
     'store.max-query-length': '12000h',  // 500 Days
     'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
-  } + if $._config.sharded_queries_enabled then {
+  } + if $._config.queryFrontend.sharded_queries_enabled then {
     'querier.parallelise-shardable-queries': 'true',
 
     // in process tenant queues on frontends. We divide by the number of frontends; 2 in this case in order to apply the global limit in aggregate.
     // basically base * shard_factor * query_split_factor / num_frontends where
-    'querier.max-outstanding-requests-per-tenant': std.floor(200 * $.query_frontend_params.shard_factor * $.query_frontend_params.query_split_factor / $.query_frontend_params.replicas),
+    'querier.max-outstanding-requests-per-tenant': std.floor(200 * $._config.queryFrontend.shard_factor * $._config.queryFrontend.query_split_factor / $._config.queryFrontend.replicas),
 
     'querier.query-ingesters-within': $._config.queryConfig['querier.query-ingesters-within'],
   } + $._config.storageConfig
@@ -67,7 +51,7 @@
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.query_frontend_args)) +
     $.jaeger_mixin +
-    if $._config.sharded_queries_enabled then
+    if $._config.queryFrontend.sharded_queries_enabled then
     $.util.resourcesRequests('2', '2Gi') +
     $.util.resourcesLimits(null, '6Gi') +
     container.withEnvMap({
@@ -76,10 +60,18 @@
     else $.util.resourcesRequests('2', '600Mi') +
     $.util.resourcesLimits(null, '1200Mi'),
 
+  local deployment = $.apps.v1beta1.deployment,
+
   query_frontend_deployment:
-    deployment.new('query-frontend', self.query_frontend_params.replicas, [$.query_frontend_container]) +
+    deployment.new('query-frontend', $._config.queryFrontend.replicas, [$.query_frontend_container]) +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
-    $.util.antiAffinity,
+    $.util.antiAffinity +
+    // inject storage schema in order to know what/how to shard
+    if $._config.queryFrontend.sharded_queries_enabled then
+    $.storage_config_mixin
+    else {},
+
+  local service = $.core.v1.service,
 
   query_frontend_service:
     $.util.serviceFor($.query_frontend_deployment) +


### PR DESCRIPTION
## What
Introduces library support for `querier.parallelise-shardable-queries`. The new jsonnet config variable, `sharded_queries_enabled` (default false) will adjust component functionality to work more ideally for sharding enabled envs.

## Why

This will allow opt in support for sharded query optimizations, enabling incremental rollouts of sharding support for different environments.