### PR TITLE
Cleanup settings assuming Cortex 0.7

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -122,7 +122,7 @@
       $._config.client_configs.cassandra +
       $._config.client_configs.gcp +
       $._config.storageTSDBConfig +
-      { 'config-yaml': '/etc/cortex/schema/config.yaml' },
+      { 'schema-config-file': '/etc/cortex/schema/config.yaml' },
 
     // TSDB blocks storage configuration, used only when 'tsdb' storage
     // engine is explicitly enabled.

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -61,8 +61,6 @@
     storage_engine: 'chunks',
     storage_tsdb_bucket_name: error 'must specify GCS bucket name to store TSDB blocks',
 
-    distributor_short_grpc_keepalive_enabled: false,
-
     // TSDB storage engine doesn't require the table manager.
     table_manager_enabled: $._config.storage_engine != 'tsdb',
 

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -25,6 +25,13 @@
       // By adding a ballast of 1G, we can drastically reduce GC, but also keep the usage at
       // around 1.25G, reducing the 99%ile.
       'mem-ballast-size-bytes': 1 << 30,  // 1GB
+
+      // The cortex-gateway should frequently reopen the connections towards the
+      // distributors in order to guarantee that new distributors receive traffic
+      // as soon as they're ready.
+      'server.grpc.keepalive.max-connection-age': '2m',
+      'server.grpc.keepalive.max-connection-age-grace': '5m',
+      'server.grpc.keepalive.max-connection-idle': '1m',
     } + (if !$._config.ingestion_rate_global_limit_enabled then {} else {
       'distributor.ingestion-rate-limit-strategy': 'global',
       'distributor.ingestion-rate-limit': 100000,  // 100K
@@ -36,13 +43,6 @@
       'distributor.ring.consul.watch-rate-limit': 1,
       'distributor.ring.consul.watch-burst-size': 1,
       'distributor.ring.prefix': '',
-    }) + (if !$._config.distributor_short_grpc_keepalive_enabled then {} else {
-      // The cortex-gateway should frequently reopen the connections towards the
-      // distributors in order to guarantee that new distributors receive traffic
-      // as soon as they're ready.
-      'server.grpc.keepalive.max-connection-age': '2m',
-      'server.grpc.keepalive.max-connection-age-grace': '5m',
-      'server.grpc.keepalive.max-connection-idle': '1m',
     }),
 
   distributor_ports:: $.util.defaultPorts,


### PR DESCRIPTION
In this PR:
- -config-yaml has been renamed to -schema-config-file in Cortex 0.7
- Removed distributor_short_grpc_keepalive_enabled feature flag (should be always enabled)