### PR TITLE
Setup CI to lint jsonnet files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+    - lint
+
+jobs:
+  lint:
+    docker:
+      - image: grafana/cortex-jsonnet-build-image:5fa1ab0
+    steps:
+      - checkout
+      - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: lint build-image publish-build-image
+
+JSONNET_FMT := jsonnetfmt
+
+lint:
+	@RESULT=0; \
+	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do \
+		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -; \
+		RESULT=$$(($$RESULT + $$?)); \
+	done; \
+	exit $$RESULT
+
+build-image:
+	docker build -t grafana/cortex-jsonnet-build-image:$(shell git rev-parse --short HEAD) build-image
+
+publish-build-image:
+	docker push grafana/cortex-jsonnet-build-image:$(shell git rev-parse --short HEAD)

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.10 AS jsonnet-builder
+RUN apk add --no-cache git make g++
+
+# Install jsonnetfmt
+RUN git clone https://github.com/google/jsonnet && \
+    git  -C jsonnet checkout v0.14.0 && \
+    make -C jsonnet 2LDFLAGS=-static && \
+    cp jsonnet/jsonnetfmt /usr/bin && \
+    rm -fr jsonnet

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -38,11 +38,11 @@
     $.jaeger_mixin +
     container.withEnvMap($.querier_env_map) +
     if $._config.queryFrontend.sharded_queries_enabled then
-    $.util.resourcesRequests('3', '12Gi') +
-    $.util.resourcesLimits(null, '24Gi')
+      $.util.resourcesRequests('3', '12Gi') +
+      $.util.resourcesLimits(null, '24Gi')
     else
-    $.util.resourcesRequests('1', '12Gi') +
-    $.util.resourcesLimits(null, '24Gi'),
+      $.util.resourcesRequests('1', '12Gi') +
+      $.util.resourcesLimits(null, '24Gi'),
 
   local deployment = $.apps.v1beta1.deployment,
 

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -52,13 +52,14 @@
     container.withArgsMixin($.util.mapToFlags($.query_frontend_args)) +
     $.jaeger_mixin +
     if $._config.queryFrontend.sharded_queries_enabled then
-    $.util.resourcesRequests('2', '2Gi') +
-    $.util.resourcesLimits(null, '6Gi') +
-    container.withEnvMap({
-      JAEGER_REPORTER_MAX_QUEUE_SIZE: '5000',
-    })
-    else $.util.resourcesRequests('2', '600Mi') +
-    $.util.resourcesLimits(null, '1200Mi'),
+      $.util.resourcesRequests('2', '2Gi') +
+      $.util.resourcesLimits(null, '6Gi') +
+      container.withEnvMap({
+        JAEGER_REPORTER_MAX_QUEUE_SIZE: '5000',
+      })
+    else
+      $.util.resourcesRequests('2', '600Mi') +
+      $.util.resourcesLimits(null, '1200Mi'),
 
   local deployment = $.apps.v1beta1.deployment,
 
@@ -68,7 +69,7 @@
     $.util.antiAffinity +
     // inject storage schema in order to know what/how to shard
     if $._config.queryFrontend.sharded_queries_enabled then
-    $.storage_config_mixin
+      $.storage_config_mixin
     else {},
 
   local service = $.core.v1.service,


### PR DESCRIPTION
Today I merged a typo in #15. The lack of any linting (and a CI to enforce it) makes it easy to merge broken config. In this PR I've configured CircleCI to lint our jsonnet files.

Example CI failed:
https://circleci.com/gh/grafana/cortex-jsonnet/2

Example CI succeeded:
https://circleci.com/gh/grafana/cortex-jsonnet/3