### PR TITLE
Add an alert for when querier index cache churn rate is too high.

### DIFF
--- a/cortex-mixin/alerts.libsonnet
+++ b/cortex-mixin/alerts.libsonnet
@@ -226,6 +226,22 @@ local windows = [
               |||,
             },
           },
+          {
+            alert: 'CortexQuerierIndexCacheChurnRate',
+            expr: |||
+              (sum(querier_cache_added_new_total{cache="store.index-cache-read.fifocache", job=~".*/querier"}) by (cluster, namespace, job)
+              - sum(querier_cache_evicted_total{cache="store.index-cache-read.fifocache", job=~".*/querier"}) by (cluster, namespace, job))
+              / sum(rate(querier_cache_evicted_total{cache="store.index-cache-read.fifocache",job=~".*/querier"}[1m])) by (cluster, namespace, job)
+               / 60 < 10
+            |||,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{labels.cluster }}/{{ $labels.namespace }} index cache churn rate is too high, entries are in cache for less than 10m.',
+            },
+          },
         ],
       },
       {


### PR DESCRIPTION
It's been a while since I did anything interesting with queries/label substitution and alerts, so let me know what we could change here to make sure this alert is useful. I based the `entries in cache < 10m` bit based on our env with the lowest value for `entries in cache / churn rate / 60s` being an average of `entry in cache for 12+ minutes`, but for other environments we have anything from 30-60 minutes.

Signed-off-by: Callum Styan <callumstyan@gmail.com>