### PR TITLE
Setup readiness probe for all Cortex components.

### DIFF
--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -29,6 +29,7 @@
     container.withArgsMixin($.util.mapToFlags($.alertmanager_args)) +
     container.withVolumeMountsMixin([volumeMount.new('alertmanager-data', '/data')]) +
     $.util.resourcesRequests('100m', '1Gi') +
+    $.util.readinessProbe +
     $.jaeger_mixin,
 
 

--- a/cortex/common.libsonnet
+++ b/cortex/common.libsonnet
@@ -4,11 +4,18 @@
 
   util+:: {
     local containerPort = $.core.v1.containerPort,
+    local container = $.core.v1.container,
 
     defaultPorts::
       [
         containerPort.newNamed(name='http-metrics', containerPort=80),
         containerPort.newNamed(name='grpc', containerPort=9095),
       ],
+
+    readinessProbe::
+      container.mixin.readinessProbe.httpGet.withPath('/ready') +
+      container.mixin.readinessProbe.httpGet.withPort(80) +
+      container.mixin.readinessProbe.withInitialDelaySeconds(15) +
+      container.mixin.readinessProbe.withTimeoutSeconds(1),
   },
 }

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -51,6 +51,7 @@
     container.withArgsMixin($.util.mapToFlags($.distributor_args)) +
     $.util.resourcesRequests('2', '2Gi') +
     $.util.resourcesLimits(null, '4Gi') +
+    $.util.readinessProbe +
     $.jaeger_mixin,
 
   local deployment = $.apps.v1beta1.deployment,

--- a/cortex/flusher-job.libsonnet
+++ b/cortex/flusher-job.libsonnet
@@ -18,12 +18,9 @@
       target: 'flusher',
       'flusher.wal-dir': $._config.wal_dir,
     })) +
-    container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
-    container.mixin.readinessProbe.withInitialDelaySeconds(15) +
-    container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('4', '15Gi') +
     $.util.resourcesLimits(null, '25Gi') +
+    $.util.readinessProbe +
     $.jaeger_mixin,
 
   flusher_job_storage_config_mixin::

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -51,12 +51,9 @@
     container.new(name, $._images.ingester) +
     container.withPorts($.ingester_ports) +
     container.withArgsMixin($.util.mapToFlags($.ingester_args)) +
-    container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
-    container.mixin.readinessProbe.withInitialDelaySeconds(15) +
-    container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.util.resourcesRequests('4', '15Gi') +
     $.util.resourcesLimits(null, '25Gi') +
+    $.util.readinessProbe +
     $.jaeger_mixin,
 
   local deployment = $.apps.v1beta1.deployment,

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -36,6 +36,7 @@
     container.withPorts($.querier_ports) +
     container.withArgsMixin($.util.mapToFlags($.querier_args)) +
     $.jaeger_mixin +
+    $.util.readinessProbe +
     container.withEnvMap($.querier_env_map) +
     if $._config.queryFrontend.sharded_queries_enabled then
       $.util.resourcesRequests('3', '12Gi') +

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -51,6 +51,7 @@
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin($.util.mapToFlags($.query_frontend_args)) +
     $.jaeger_mixin +
+    $.util.readinessProbe +
     if $._config.queryFrontend.sharded_queries_enabled then
       $.util.resourcesRequests('2', '2Gi') +
       $.util.resourcesLimits(null, '6Gi') +

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -28,6 +28,7 @@
     container.withArgsMixin($.util.mapToFlags($.ruler_args)) +
     $.util.resourcesRequests('1', '6Gi') +
     $.util.resourcesLimits('16', '16Gi') +
+    $.util.readinessProbe +
     $.jaeger_mixin,
 
   local deployment = $.apps.v1beta1.deployment,

--- a/cortex/table-manager.libsonnet
+++ b/cortex/table-manager.libsonnet
@@ -35,6 +35,7 @@
       container.withArgsMixin($.util.mapToFlags($.table_manager_args)) +
       $.util.resourcesRequests('100m', '100Mi') +
       $.util.resourcesLimits('200m', '200Mi') +
+      $.util.readinessProbe +
       $.jaeger_mixin
     else {},
 

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -41,10 +41,6 @@
   },
 
   querier_container+::
-    container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort(80) +
-    container.mixin.readinessProbe.withInitialDelaySeconds(5) +
-    container.mixin.readinessProbe.withTimeoutSeconds(1) +
     container.withVolumeMountsMixin([
       volumeMount.new('querier-data', '/data'),
     ]),
@@ -139,6 +135,7 @@
     container.withVolumeMountsMixin([volumeMount.new('compactor-data', '/data')]) +
     $.util.resourcesRequests('1', '6Gi') +
     $.util.resourcesLimits('1', '6Gi') +
+    $.util.readinessProbe +
     $.jaeger_mixin,
 
   compactor_statefulset:


### PR DESCRIPTION
All cortex components now have `/ready` endpoint available, so we can use it as readiness probe.