### PR TITLE
remove gateway recording rules and alerts

### DIFF
--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -1,13 +1,4 @@
 local utils = import 'mixin-utils/utils.libsonnet';
-local windows = [
-  { period: '5m' },
-  { period: '30m' },
-  { period: '1h' },
-  { period: '2h' },
-  { period: '6h' },
-  { period: '1d' },
-  { period: '3d' },
-];
 
 {
   prometheus_rules+:: {
@@ -35,45 +26,6 @@ local windows = [
         utils.histogramRules('cortex_database_request_duration_seconds', ['cluster', 'job', 'method']) +
         utils.histogramRules('cortex_gcs_request_duration_seconds', ['cluster', 'job', 'operation']) +
         utils.histogramRules('cortex_kv_request_duration_seconds', ['cluster', 'job']),
-    }, {
-      name: 'cortex_slo_rules',
-      rules: [
-        {
-          record: 'namespace_job:cortex_gateway_write_slo_errors_per_request:ratio_rate%(period)s' % window,
-          expr: |||
-            1 -
-            (
-              sum by (namespace, job) (rate(cortex_request_duration_seconds_bucket{status_code!~"5..", le="1", route="api_prom_push", job=~".*/cortex-gw"}[%(period)s]))
-            /
-              sum by (namespace, job) (rate(cortex_request_duration_seconds_count{route="api_prom_push", job=~".*/cortex-gw"}[%(period)s]))
-            )
-          ||| % window,
-        }
-        for window in windows
-      ] + [
-        {
-          record: 'namespace_job:cortex_gateway_read_slo_errors_per_request:ratio_rate%(period)s' % window,
-          expr: |||
-            1 -
-            (
-              sum by (namespace, job) (rate(cortex_request_duration_seconds_bucket{status_code!~"5..",le="2.5",route=~"api_prom_api_v1_query.*", job=~".*/cortex-gw"}[%(period)s]))
-            /
-              sum by (namespace, job) (rate(cortex_request_duration_seconds_count{route=~"api_prom_api_v1_query.*", job=~".*/cortex-gw"}[%(period)s]))
-            )
-          ||| % window,
-        }
-        for window in windows
-      ],
-    }, {
-      name: 'cortex_received_samples',
-      rules: [
-        {
-          record: 'cluster_namespace:cortex_distributor_received_samples:rate5m',
-          expr: |||
-            sum by (cluster, namespace) (rate(cortex_distributor_received_samples_total{job=~".*/distributor"}[5m]))
-          |||,
-        },
-      ],
     }],
   },
 }

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -24,9 +24,6 @@
       // around 1.25G, reducing the 99%ile.
       'mem-ballast-size-bytes': 1 << 30,  // 1GB
 
-      // The cortex-gateway should frequently reopen the connections towards the
-      // distributors in order to guarantee that new distributors receive traffic
-      // as soon as they're ready.
       'server.grpc.keepalive.max-connection-age': '2m',
       'server.grpc.keepalive.max-connection-age-grace': '5m',
       'server.grpc.keepalive.max-connection-idle': '1m',


### PR DESCRIPTION
Removes gateway related recording rules and alerts since the gateway is not part of cortex-jsonnet.

Signed-off-by: Callum Styan <callumstyan@gmail.com>