### PR TITLE
Forgot to remove the import of recording_rules.jsonet

### DIFF
--- a/cortex-mixin/mixin.libsonnet
+++ b/cortex-mixin/mixin.libsonnet
@@ -1,3 +1,2 @@
 (import 'dashboards.libsonnet') +
-(import 'alerts.libsonnet') +
-(import 'recording_rules.libsonnet')
+(import 'alerts.libsonnet')

--- a/cortex-mixin/recording_rules.jsonnet
+++ b/cortex-mixin/recording_rules.jsonnet
@@ -1,1 +1,0 @@
-std.manifestYamlDoc((import 'mixin.libsonnet').prometheus_rules)


### PR DESCRIPTION
Removing since we no longer have prometheus_rules for recording rules. Missed this in #33

Signed-off-by: Callum Styan <callumstyan@gmail.com>