### PR TITLE
Fix lint errors in dashboards mixin.libsonnet.

### DIFF
--- a/cortex-mixin/mixin.libsonnet
+++ b/cortex-mixin/mixin.libsonnet
@@ -1,6 +1,6 @@
 (import 'dashboards.libsonnet') +
 (import 'alerts.libsonnet') +
 (import 'recording_rules.libsonnet') {
-    grafanaDashboardFolder: "Cortex",
-    grafanaDashboardShards: 4,
+  grafanaDashboardFolder: 'Cortex',
+  grafanaDashboardShards: 4,
 }


### PR DESCRIPTION
Just fixing some lint failures from one the recent dashboard folders changes.

Signed-off-by: Callum Styan <callumstyan@gmail.com>