### PR TITLE
Added store-gateway support

### DIFF
--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -15,6 +15,7 @@
     compactor: self.cortex,
     flusher: self.cortex,
     ruler: self.cortex,
+    store_gateway: self.cortex,
 
     query_tee: 'quay.io/cortexproject/query-tee:master-5d7b05c3',
     // TODO(gouthamve/jtlisi): Upstream the ruler and AM configs.


### PR DESCRIPTION
In this PR I'm adding the support for the Cortex store-gateway. The changes have no impact if the storage engine is not `tsdb`.