### PR TITLE
Immediately join ingesters in the ring when using the blocks storage

### DIFF
--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -82,6 +82,7 @@
   ingester_args+:: {
     // Disable TSDB blocks transfer because of persistent volumes
     'ingester.max-transfer-retries': 0,
+    'ingester.join-after': '0s',
 
     // Persist ring tokens so that when the ingester will be restarted
     // it will pick the same tokens


### PR DESCRIPTION
When using the blocks storage we do disable blocks transfer on ingesters shutdown (because of the WAL on persistent disks) so I don't see a good reason to wait 30s before a new ingester joins the ring (is there?).