### PR TITLE
Fix dashboard function

### DIFF
--- a/cortex-mixin/dashboards/blocks.libsonnet
+++ b/cortex-mixin/dashboards/blocks.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-blocks.json':
-    $.dashboard('Cortex / Blocks')
+    $.cortexDashboard('Cortex / Blocks')
     .addClusterSelectorTemplates()
     // repeated from Cortex / Chunks
     .addRow(

--- a/cortex-mixin/dashboards/chunks.libsonnet
+++ b/cortex-mixin/dashboards/chunks.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-chunks.json':
-    $.dashboard('Cortex / Chunks')
+    $.cortexDashboard('Cortex / Chunks')
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Active Series / Chunks')

--- a/cortex-mixin/dashboards/comparison.libsonnet
+++ b/cortex-mixin/dashboards/comparison.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet')
 {
   'cortex-blocks-vs-chunks.json':
-    $.dashboard('Cortex / Blocks vs Chunks')
+    $.cortexDashboard('Cortex / Blocks vs Chunks')
     .addMultiTemplate('cluster', 'kube_pod_container_info{image=~".*cortex.*"}', 'cluster')
     .addTemplate('blocks_namespace', 'kube_pod_container_info{image=~".*cortex.*"}', 'namespace')
     .addTemplate('chunks_namespace', 'kube_pod_container_info{image=~".*cortex.*"}', 'namespace')

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -7,7 +7,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   // Override the dashboard constructor to add:
   // - default tags,
   // - some links that propagate the selectred cluster.
-  dashboard(title)::
+  cortexDashboard(title)::
     super.dashboard(title) + {
       addRowIf(condition, row)::
         if condition

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
 
   'cortex-queries.json':
-    $.dashboard('Cortex / Queries')
+    $.cortexDashboard('Cortex / Queries')
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Query Frontend')

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-reads.json':
-    $.dashboard('Cortex / Reads')
+    $.cortexDashboard('Cortex / Reads')
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Gateway')

--- a/cortex-mixin/dashboards/ruler.libsonnet
+++ b/cortex-mixin/dashboards/ruler.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
 
   'ruler.json':
-    $.dashboard('Cortex / Ruler')
+    $.cortexDashboard('Cortex / Ruler')
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Rule Evaluations')

--- a/cortex-mixin/dashboards/scaling.libsonnet
+++ b/cortex-mixin/dashboards/scaling.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
 
   'cortex-scaling.json':
-    $.dashboard('Cortex / Scaling')
+    $.cortexDashboard('Cortex / Scaling')
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Workload-based scaling')

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-writes.json':
-    $.dashboard('Cortex / Writes')
+    $.cortexDashboard('Cortex / Writes')
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Headlines') +


### PR DESCRIPTION
I'm trying to update the vendored mixin in `deployment_tools` and I'm getting this error:

```
evaluating jsonnet: RUNTIME ERROR: Field does not exist: addClusterSelectorTemplates
	/workspace/deployment_tools/ksonnet/vendor/cortex-mixin/dashboards/queries.libsonnet:(6:5)-(7:33)
	/workspace/deployment_tools/ksonnet/vendor/prometheus-ksonnet/grafana/dashboards.libsonnet:28:27-54	thunk <dashboard> from <object <anonymous>>
	/workspace/deployment_tools/ksonnet/vendor/prometheus-ksonnet/grafana/dashboards.libsonnet:29:9-18	object <anonymous>
	/workspace/deployment_tools/ksonnet/vendor/prometheus-ksonnet/grafana/dashboards.libsonnet:83:30-46	thunk from <object <anonymous>>
	/workspace/deployment_tools/ksonnet/vendor/prometheus-ksonnet/grafana/dashboards.libsonnet:83:17-47	object <anonymous>
	During manifestation
```

I'm probably lacking some jsonnet knowledge here, but I can't find a way to get the `dashboard()` function override correctly working, while it works if I rename that function to something different (so that it's not an override anymore).

Does anyone know how to fix it without renaming the function? If not, I would suggest to rename it so we unblock.