### PR TITLE
Updated Object Store metrics in dashboards

### DIFF
--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -7,7 +7,9 @@
     (import 'dashboards/writes.libsonnet') +
 
     (if std.setMember('tsdb', $._config.storage_engine)
-     then import 'dashboards/compactor.libsonnet'
+     then
+       (import 'dashboards/compactor.libsonnet') +
+       (import 'dashboards/object-store.libsonnet')
      else {}) +
 
     (if std.setMember('chunks', $._config.storage_engine)

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -84,6 +84,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.latencyPanel('cortex_compactor_meta_sync_duration_seconds', '{%s}' % $.jobMatcher('compactor')),
       )
     )
-    .addRow($.objectStorePanels1('Object Store', 'cortex_compactor'))
-    .addRow($.objectStorePanels2('', 'cortex_compactor')),
+    .addRow($.objectStorePanels1('Object Store', 'compactor'))
+    .addRow($.objectStorePanels2('', 'compactor')),
 }

--- a/cortex-mixin/dashboards/object-store.libsonnet
+++ b/cortex-mixin/dashboards/object-store.libsonnet
@@ -1,0 +1,65 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+  'cortex-object-store.json':
+    $.dashboard('Cortex / Object Store')
+    .addClusterSelectorTemplates()
+    .addRow(
+      $.row('Components')
+      .addPanel(
+        $.panel('RPS / component') +
+        $.queryPanel('sum by(component) (rate(thanos_objstore_bucket_operations_total{%s}[$__interval]))' % $.namespaceMatcher(), '{{component}}') +
+        $.stack +
+        { yaxes: $.yaxes('rps') },
+      )
+      .addPanel(
+        $.panel('Error rate / component') +
+        $.queryPanel('sum by(component) (rate(thanos_objstore_bucket_operation_failures_total{%s}[$__interval])) / sum by(component) (rate(thanos_objstore_bucket_operations_total{%s}[$__interval]))' % [$.namespaceMatcher(), $.namespaceMatcher()], '{{component}}') +
+        { yaxes: $.yaxes('percentunit') },
+      )
+    )
+    .addRow(
+      $.row('Operations')
+      .addPanel(
+        $.panel('RPS / operation') +
+        $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s}[$__interval]))' % $.namespaceMatcher(), '{{operation}}') +
+        $.stack +
+        { yaxes: $.yaxes('rps') },
+      )
+      .addPanel(
+        $.panel('Error rate / operation') +
+        $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operation_failures_total{%s}[$__interval])) / sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s}[$__interval]))' % [$.namespaceMatcher(), $.namespaceMatcher()], '{{operation}}') +
+        { yaxes: $.yaxes('percentunit') },
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.panel('Op: Get') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,operation="get"}' % $.namespaceMatcher()),
+      )
+      .addPanel(
+        $.panel('Op: GetRange') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,operation="get_range"}' % $.namespaceMatcher()),
+      )
+      .addPanel(
+        $.panel('Op: Exists') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,operation="exists"}' % $.namespaceMatcher()),
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.panel('Op: ObjectSize') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,operation="objectsize"}' % $.namespaceMatcher()),
+      )
+      .addPanel(
+        $.panel('Op: Upload') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,operation="upload"}' % $.namespaceMatcher()),
+      )
+      .addPanel(
+        $.panel('Op: Delete') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,operation="delete"}' % $.namespaceMatcher()),
+      )
+    ),
+}

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -169,19 +169,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // Object store metrics for the store-gateway.
     .addRowIf(
       std.setMember('tsdb', $._config.storage_engine),
-      $.objectStorePanels1('Store-gateway - Blocks Object Store', 'cortex_storegateway'),
+      $.objectStorePanels1('Store-gateway - Blocks Object Store', 'store-gateway'),
     )
     .addRowIf(
       std.setMember('tsdb', $._config.storage_engine),
-      $.objectStorePanels2('', 'cortex_storegateway'),
+      $.objectStorePanels2('', 'store-gateway'),
     )
     // Object store metrics for the querier.
     .addRowIf(
       std.setMember('tsdb', $._config.storage_engine),
-      $.objectStorePanels1('Querier - Blocks Object Store', 'cortex_querier'),
+      $.objectStorePanels1('Querier - Blocks Object Store', 'querier'),
     )
     .addRowIf(
       std.setMember('tsdb', $._config.storage_engine),
-      $.objectStorePanels2('', 'cortex_querier'),
+      $.objectStorePanels2('', 'querier'),
     ),
 }

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -151,21 +151,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.setMember('tsdb', $._config.storage_engine),
-      $.row('Blocks Shipper')
+      $.row('Ingester - Blocks storage - Shipper')
       .addPanel(
         $.successFailurePanel(
           'Uploaded blocks / sec',
-          'sum(rate(cortex_ingester_shipper_uploads_total{%s}[$__interval])) - sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__interval]))' % [$.namespaceMatcher(), $.namespaceMatcher()],
-          'sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__interval]))' % [$.namespaceMatcher()],
+          'sum(rate(cortex_ingester_shipper_uploads_total{%s}[$__interval])) - sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__interval]))' % [$.jobMatcher('ingester'), $.jobMatcher('ingester')],
+          'sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__interval]))' % $.jobMatcher('ingester'),
         ),
       )
-    )
-    .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
-      $.objectStorePanels1('Blocks Object Store Stats (Ingester)', 'cortex_ingester'),
-    )
-    .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
-      $.objectStorePanels2('', 'cortex_ingester'),
+      .addPanel(
+        $.panel('Upload latency') +
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="ingester",operation="upload"}' % $.jobMatcher('ingester')),
+      )
     ),
 }


### PR DESCRIPTION
This PR updates objstore metrics reflecting changes done in https://github.com/cortexproject/cortex/pull/2568. Some notes:

1. Created a new dashboard "Cortex / Object Store" to give an overview over all API calls to the store
2. Kept objstore panels in "Cortex / Reads" and "Cortex / Compactor", but added a per-operation QPS + per operation error rate (removed also "Op: Iter" because included in the per-operation QPS)
3. Removed the detailed objstore metrics from "Cortex / Writes" but added "Upload latency" to the shipper metrics row


### Preview: Cortex / Reads

![Screen Shot 2020-05-08 at 11 04 55](https://user-images.githubusercontent.com/1701904/81390451-c7c5e080-911b-11ea-95cd-f57212d1140f.png)

### Preview: Cortex / Writes

![Screen Shot 2020-05-08 at 11 05 39](https://user-images.githubusercontent.com/1701904/81390511-e1672800-911b-11ea-8080-60ab0f56d79a.png)


### Preview: Cortex / Object Store

![Screen Shot 2020-05-08 at 11 05 15](https://user-images.githubusercontent.com/1701904/81390489-d4e2cf80-911b-11ea-881b-ad14f085dd0b.png)
