### PR TITLE
Added blocks storage alerts

### DIFF
--- a/cortex-mixin/alerts.libsonnet
+++ b/cortex-mixin/alerts.libsonnet
@@ -2,5 +2,11 @@
   prometheusAlerts+::
     (import 'alerts/alerts.libsonnet') +
 
+    (if std.setMember('tsdb', $._config.storage_engine)
+     then
+       (import 'alerts/blocks.libsonnet') +
+       (import 'alerts/compactor.libsonnet')
+     else {}) +
+
     { _config:: $._config },
 }

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -56,7 +56,7 @@
           expr: |||
             (time() - cortex_storegateway_blocks_last_successful_sync_timestamp_seconds{%s} > 60 * 30)
             and
-            cortex_storegateway_blocks_last_successful_sync_timestamp_seconds > 0
+            cortex_storegateway_blocks_last_successful_sync_timestamp_seconds{%s} > 0
           ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
           labels: {
             severity: 'critical',

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -33,7 +33,7 @@
             message: 'Cortex Ingester {{ $labels.namespace }}/{{ $labels.instance }} has not shipped any block in the last 4 hours.',
           },
         },
-      ]
-    }
+      ],
+    },
   ],
 }

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -33,6 +33,38 @@
             message: 'Cortex Ingester {{ $labels.namespace }}/{{ $labels.instance }} has not shipped any block in the last 4 hours.',
           },
         },
+        {
+          // Alert if the querier is not successfully scanning the bucket.
+          alert: 'CortexQuerierHasNotScanTheBucket',
+          'for': '5m',
+          expr: |||
+            (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 60 * 30)
+            and
+            cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 0
+          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Querier {{ $labels.namespace }}/{{ $labels.instance }} has not successfully scanned the bucket since {{ $value | humanizeDuration }}.',
+          },
+        },
+        {
+          // Alert if the store-gateway is not successfully synching the bucket.
+          alert: 'CortexStoreGatewayHasNotSyncTheBucket',
+          'for': '5m',
+          expr: |||
+            (time() - cortex_storegateway_blocks_last_successful_sync_timestamp_seconds{%s} > 60 * 30)
+            and
+            cortex_storegateway_blocks_last_successful_sync_timestamp_seconds > 0
+          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Store Gateway {{ $labels.namespace }}/{{ $labels.instance }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.',
+          },
+        },
       ],
     },
   ],

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -41,7 +41,7 @@
             (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 60 * 30)
             and
             cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 0
-          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
           labels: {
             severity: 'critical',
           },
@@ -57,7 +57,7 @@
             (time() - cortex_storegateway_blocks_last_successful_sync_timestamp_seconds{%s} > 60 * 30)
             and
             cortex_storegateway_blocks_last_successful_sync_timestamp_seconds{%s} > 0
-          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
           labels: {
             severity: 'critical',
           },

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -1,0 +1,39 @@
+(import 'alert-utils.libsonnet') {
+  groups+: [
+    {
+      name: 'cortex_blocks_alerts',
+      rules: [
+        {
+          // Alert if the ingester has not shipped any block in the last 4h.
+          alert: 'CortexIngesterHasNotShippedBlocks',
+          'for': '15m',
+          expr: |||
+            (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"%s} > 60 * 60 * 4)
+            and
+            (thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"%s} > 0)
+          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Ingester {{ $labels.namespace }}/{{ $labels.instance }} has not shipped any block in the last 4 hours.',
+          },
+        },
+        {
+          // Alert if the ingester has not shipped any block since start.
+          alert: 'CortexIngesterHasNotShippedBlocks',
+          'for': '4h',
+          expr: |||
+            thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"%s} == 0
+          ||| % $.namespace_matcher(','),
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Ingester {{ $labels.namespace }}/{{ $labels.instance }} has not shipped any block in the last 4 hours.',
+          },
+        },
+      ]
+    }
+  ],
+}

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -4,8 +4,38 @@
       name: 'cortex_compactor_alerts',
       rules: [
         {
+          // Alert if the compactor has not successfully completed a run in the last 24h.
+          alert: 'CortexCompactorHasNotSuccessfullyRun',
+          'for': '15m',
+          expr: |||
+            (time() - cortex_compactor_last_successful_run_timestamp_seconds{%s} > 60 * 60 * 24)
+            and
+            (cortex_compactor_last_successful_run_timestamp_seconds > 0)
+          ||| % $.namespace_matcher(','),
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not successfully completed a run in the last 24 hours.',
+          },
+        },
+        {
+          // Alert if the compactor has not successfully completed a run since its start.
+          alert: 'CortexCompactorHasNotSuccessfullyRunSinceStart',
+          'for': '24h',
+          expr: |||
+            cortex_compactor_last_successful_run_timestamp_seconds{%s} == 0
+          ||| % $.namespace_matcher(','),
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not successfully completed a run in the last 24 hours.',
+          },
+        },
+        {
           // Alert if the compactor has not uploaded anything in the last 24h.
-          alert: 'CortexCompactorHasNotRun',
+          alert: 'CortexCompactorHasNotUploadedBlocks',
           'for': '15m',
           expr: |||
             (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 60 * 60 * 24)
@@ -16,12 +46,12 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded anything in the last 24 hours.',
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded any block in the last 24 hours.',
           },
         },
         {
           // Alert if the compactor has not uploaded anything since its start.
-          alert: 'CortexCompactorHasNotRunSinceStart',
+          alert: 'CortexCompactorHasNotUploadedBlocksSinceStart',
           'for': '24h',
           expr: |||
             thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} == 0
@@ -30,7 +60,7 @@
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded anything in the last 24 hours.',
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded any block in the last 24 hours.',
           },
         },
       ],

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -33,7 +33,7 @@
             message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded anything in the last 24 hours.',
           },
         },
-      ]
-    }
+      ],
+    },
   ],
 }

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -1,0 +1,39 @@
+(import 'alert-utils.libsonnet') {
+  groups+: [
+    {
+      name: 'cortex_compactor_alerts',
+      rules: [
+        {
+          // Alert if the compactor has not uploaded anything in the last 24h.
+          alert: 'CortexCompactorHasNotRun',
+          'for': '15m',
+          expr: |||
+            (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 60 * 60 * 24)
+            and
+            (thanos_objstore_bucket_last_successful_upload_time > 0)
+          ||| % $.namespace_matcher(','),
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded anything in the last 24 hours.',
+          },
+        },
+        {
+          // Alert if the compactor has not uploaded anything since its start.
+          alert: 'CortexCompactorHasNotRunSinceStart',
+          'for': '24h',
+          expr: |||
+            thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} == 0
+          ||| % $.namespace_matcher(','),
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not uploaded anything in the last 24 hours.',
+          },
+        },
+      ]
+    }
+  ],
+}

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -10,8 +10,8 @@
           expr: |||
             (time() - cortex_compactor_last_successful_run_timestamp_seconds{%s} > 60 * 60 * 24)
             and
-            (cortex_compactor_last_successful_run_timestamp_seconds > 0)
-          ||| % $.namespace_matcher(','),
+            (cortex_compactor_last_successful_run_timestamp_seconds{%s} > 0)
+          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
           labels: {
             severity: 'critical',
           },
@@ -40,8 +40,8 @@
           expr: |||
             (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 60 * 60 * 24)
             and
-            (thanos_objstore_bucket_last_successful_upload_time > 0)
-          ||| % $.namespace_matcher(','),
+            (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 0)
+          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
           labels: {
             severity: 'critical',
           },

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -11,7 +11,7 @@
             (time() - cortex_compactor_last_successful_run_timestamp_seconds{%s} > 60 * 60 * 24)
             and
             (cortex_compactor_last_successful_run_timestamp_seconds{%s} > 0)
-          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
           labels: {
             severity: 'critical',
           },
@@ -25,7 +25,7 @@
           'for': '24h',
           expr: |||
             cortex_compactor_last_successful_run_timestamp_seconds{%s} == 0
-          ||| % $.namespace_matcher(','),
+          ||| % $.namespace_matcher(''),
           labels: {
             severity: 'critical',
           },


### PR DESCRIPTION
Existing Cortex alerts already cover the write and read path of the blocks storage too, but there are few critical conditions not covered.

In this PR:
- Compactor has not successfully shipped blocks
- Compactor has not successfully completed a run
- Ingester is not successfully shipping blocks
- Querier has not successfully completed a bucket scan
- Store-gateway has not successfully completed a bucket sync
