### PR TITLE
Alert for Ruler Rule Ownership Check

### DIFF
--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -423,6 +423,22 @@
             |||,
           },
         },
+        {
+          alert: 'CortexRulerFailedRingCheck',
+          expr: |||
+            sum(rate(cortex_ruler_ring_check_errors_total[5m]) by (namespace, job)
+               > 0
+          |||,
+          'for': '1m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: |||
+              {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% errors when checking the ring for rule group ownership.
+            |||,
+          },
+        },
       ],
     },
     {

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -69,3 +69,7 @@ This alert goes off when an ingester is marked as unhealthy. Check the ring web 
 
 ## MemcachedDown
 @todo
+
+## CortexRulerFailedRingCheck
+
+This alert occurs when a ruler is unable to validate whether or not it should claim ownership over the evaluation of a rule group. The most likely cause is that one of the rule ring entries is unhealthy. If this is the case proceed to the ring admin http page and forget the unhealth ruler. The other possible cause would be an error returned the ring client. If this is the case look into debugging the ring based on the in-use backend implementation.


### PR DESCRIPTION
This alert ensures that a ruler instance can successfully verify that it owns a rule group and should evaluate it.

The fix is currently manual. However, https://github.com/cortexproject/cortex/issues/2058 this upstream issue would make the fix automatic in most cases.