### PR TITLE
Added 'Writes Resources' and 'Reads Resources' dashboards

### DIFF
--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -25,5 +25,8 @@
 
     cortex_p99_latency_threshold_seconds: 2.5,
     alert_namespace_matcher: '',
+
+    // Whether resources dashboards are enabled (based on cAdvisor metrics).
+    resources_dashboards_enabled: false,
   },
 }

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -2,9 +2,11 @@
   grafanaDashboards+:
     (import 'dashboards/queries.libsonnet') +
     (import 'dashboards/reads.libsonnet') +
+    (import 'dashboards/reads-resources.libsonnet') +
     (import 'dashboards/ruler.libsonnet') +
     (import 'dashboards/scaling.libsonnet') +
     (import 'dashboards/writes.libsonnet') +
+    (import 'dashboards/writes-resources.libsonnet') +
 
     (if std.setMember('tsdb', $._config.storage_engine)
      then import 'dashboards/compactor.libsonnet'

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -2,11 +2,9 @@
   grafanaDashboards+:
     (import 'dashboards/queries.libsonnet') +
     (import 'dashboards/reads.libsonnet') +
-    (import 'dashboards/reads-resources.libsonnet') +
     (import 'dashboards/ruler.libsonnet') +
     (import 'dashboards/scaling.libsonnet') +
     (import 'dashboards/writes.libsonnet') +
-    (import 'dashboards/writes-resources.libsonnet') +
 
     (if std.setMember('tsdb', $._config.storage_engine)
      then import 'dashboards/compactor.libsonnet'
@@ -20,6 +18,10 @@
         && std.setMember('chunks', $._config.storage_engine)
      then import 'dashboards/comparison.libsonnet'
      else {}) +
+
+    (if !$._config.resources_dashboards_enabled then {} else
+      (import 'dashboards/reads-resources.libsonnet') +
+      (import 'dashboards/writes-resources.libsonnet')) +
 
     { _config:: $._config },
 }

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -20,8 +20,8 @@
      else {}) +
 
     (if !$._config.resources_dashboards_enabled then {} else
-      (import 'dashboards/reads-resources.libsonnet') +
-      (import 'dashboards/writes-resources.libsonnet')) +
+       (import 'dashboards/reads-resources.libsonnet') +
+       (import 'dashboards/writes-resources.libsonnet')) +
 
     { _config:: $._config },
 }

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -1,0 +1,65 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+  'cortex-reads-resources.json':
+    $.dashboard('Cortex / Reads Resources')
+    .addClusterSelectorTemplates()
+    .addRow(
+      $.row('Gateway')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'cortex-gw'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw'),
+      )
+    )
+    .addRow(
+      $.row('Query Frontend')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'query-frontend'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-frontend'),
+      )
+    )
+    .addRow(
+      $.row('Querier')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'querier'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'querier'),
+      )
+    )
+    .addRowIf(
+      std.setMember('tsdb', $._config.storage_engine),
+      $.row('Store-gateway')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'store-gateway'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'store-gateway'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'store-gateway'),
+      )
+    ) + {
+      templating+: {
+        list: [
+          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // risks to explode because it shows resources per pod.
+          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          for l in super.list
+        ],
+      },
+    },
+}

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -1,0 +1,59 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+  'cortex-writes-resources.json':
+    $.dashboard('Cortex / Writes Resources')
+    .addClusterSelectorTemplates()
+    .addRow(
+      $.row('Gateway')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'cortex-gw'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw'),
+      )
+    )
+    .addRow(
+      $.row('Distributor')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'distributor'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'distributor'),
+      )
+    )
+    .addRow(
+      $.row('Ingester')
+      .addPanel(
+        $.panel('In-memory series') +
+        $.queryPanel('sum by(instance) (cortex_ingester_memory_series{%s})' % $.jobMatcher('ingester'), '{{instance}}'),
+      )
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'ingester'),
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ingester'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
+      )
+    ) + {
+      templating+: {
+        list: [
+          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // risks to explode because it shows resources per pod.
+          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          for l in super.list
+        ],
+      },
+    },
+}


### PR DESCRIPTION
While investigating performance issues (ie. high latency), I frequently find myself starting from basic resources metrics like CPU and memory. In this PR I'm proposing to add two new dashboards:

- "Cortex / Write Resources" covering CPU / memory in the write path
- "Cortex / Read Resources" covering CPU / memory in the read path

### Previews

![Screen Shot 2020-05-13 at 12 21 10](https://user-images.githubusercontent.com/1701904/81801271-6d11f780-9514-11ea-9236-2387d5ec0de1.png)

![Screen Shot 2020-05-13 at 12 21 13](https://user-images.githubusercontent.com/1701904/81801283-700ce800-9514-11ea-817c-a6dda2c400e0.png)

