### PR TITLE
Expose store-gateway via service

### DIFF
--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -194,4 +194,7 @@
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120),
+
+  store_gateway_service:
+    $.util.serviceFor($.store_gateway_statefulset),
 }


### PR DESCRIPTION
In order to be able to internally access store-gateway endpoints (ie. `/store-gateway/ring`) we need to expose a service first.