### PR TITLE
Split recording rules into separate groups

### DIFF
--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -15,7 +15,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         rules:
           utils.histogramRules('cortex_memcache_request_duration_seconds', ['cluster', 'job', 'method']) +
           utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job']) +
-          utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job', 'method'])
+          utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job', 'method']),
       },
       {
         name: 'cortex_chunk_store',
@@ -33,12 +33,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
       {
         name: 'cortex_queries',
-        rules: 
+        rules:
           utils.histogramRules('cortex_query_frontend_retries', ['cluster', 'job']) +
           utils.histogramRules('cortex_query_frontend_queue_duration_seconds', ['cluster', 'job']) +
           utils.histogramRules('cortex_ingester_queried_series', ['cluster', 'job']) +
           utils.histogramRules('cortex_ingester_queried_chunks', ['cluster', 'job']) +
-          utils.histogramRules('cortex_ingester_queried_samples', ['cluster', 'job'])
+          utils.histogramRules('cortex_ingester_queried_samples', ['cluster', 'job']),
       },
       {
         name: 'cortex_received_samples',

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -18,7 +18,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job', 'method']),
       },
       {
-        name: 'cortex_chunk_store',
+        name: 'cortex_storage',
         rules:
           utils.histogramRules('cortex_bigtable_request_duration_seconds', ['cluster', 'job', 'operation']) +
           utils.histogramRules('cortex_cassandra_request_duration_seconds', ['cluster', 'job', 'operation']) +

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -4,22 +4,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
   prometheusRules+:: {
     groups+: [
       {
-        name: 'cortex_rules',
+        name: 'cortex_api',
         rules:
           utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'job']) +
           utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'job', 'route']) +
-          utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'namespace', 'job', 'route']) +
+          utils.histogramRules('cortex_request_duration_seconds', ['cluster', 'namespace', 'job', 'route']),
+      },
+      {
+        name: 'cortex_cache',
+        rules:
           utils.histogramRules('cortex_memcache_request_duration_seconds', ['cluster', 'job', 'method']) +
           utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job']) +
-          utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job', 'method']) +
+          utils.histogramRules('cortex_cache_request_duration_seconds', ['cluster', 'job', 'method'])
+      },
+      {
+        name: 'cortex_chunk_store',
+        rules:
           utils.histogramRules('cortex_bigtable_request_duration_seconds', ['cluster', 'job', 'operation']) +
           utils.histogramRules('cortex_cassandra_request_duration_seconds', ['cluster', 'job', 'operation']) +
           utils.histogramRules('cortex_dynamo_request_duration_seconds', ['cluster', 'job', 'operation']) +
-          utils.histogramRules('cortex_query_frontend_retries', ['cluster', 'job']) +
-          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', ['cluster', 'job']) +
-          utils.histogramRules('cortex_ingester_queried_series', ['cluster', 'job']) +
-          utils.histogramRules('cortex_ingester_queried_chunks', ['cluster', 'job']) +
-          utils.histogramRules('cortex_ingester_queried_samples', ['cluster', 'job']) +
           utils.histogramRules('cortex_chunk_store_index_lookups_per_query', ['cluster', 'job']) +
           utils.histogramRules('cortex_chunk_store_series_pre_intersection_per_query', ['cluster', 'job']) +
           utils.histogramRules('cortex_chunk_store_series_post_intersection_per_query', ['cluster', 'job']) +
@@ -27,6 +30,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
           utils.histogramRules('cortex_database_request_duration_seconds', ['cluster', 'job', 'method']) +
           utils.histogramRules('cortex_gcs_request_duration_seconds', ['cluster', 'job', 'operation']) +
           utils.histogramRules('cortex_kv_request_duration_seconds', ['cluster', 'job']),
+      },
+      {
+        name: 'cortex_queries',
+        rules: 
+          utils.histogramRules('cortex_query_frontend_retries', ['cluster', 'job']) +
+          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', ['cluster', 'job']) +
+          utils.histogramRules('cortex_ingester_queried_series', ['cluster', 'job']) +
+          utils.histogramRules('cortex_ingester_queried_chunks', ['cluster', 'job']) +
+          utils.histogramRules('cortex_ingester_queried_samples', ['cluster', 'job'])
       },
       {
         name: 'cortex_received_samples',


### PR DESCRIPTION
The size of the rule group for recording rules in this mixin is getting a bit large. It's currently taking `>15s` to run on a standard prometheus: 

![image](https://user-images.githubusercontent.com/6921077/82943355-7c0e9600-9f67-11ea-8009-f4bcfb00c0cc.png)

This PR breaks the recording rules for cortex into smaller rule groups which provide a bit more wiggle room for anyone with low eval intervals on their recording rules to avoid missed iterations.