### PR TITLE
Configure metadata cache when using blocks storage.

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -75,6 +75,9 @@
     memcached_chunks_enabled: true,
     memcached_chunks_max_item_size_mb: 1,
 
+    memcached_metadata_enabled: $._config.storage_engine == 'tsdb',
+    memcached_metadata_max_item_size_mb: 1,
+
     // The query-tee is an optional service which can be used to send
     // the same input query to multiple backends and make them compete
     // (comparing performances).

--- a/cortex/memcached.libsonnet
+++ b/cortex/memcached.libsonnet
@@ -62,4 +62,18 @@ memcached {
         container.withArgsMixin(['-c 4096']),
     }
   else {},
+
+  // Memcached instance for caching TSDB blocks metadata (meta.json files, deletion marks, list of users and blocks).
+  memcached_metadata: if $._config.memcached_metadata_enabled then
+    $.memcached {
+      name: 'memcached-metadata',
+      max_item_size: '%dm' % [$._config.memcached_metadata_max_item_size_mb],
+
+      // Metadata cache doesn't need much memory.
+      memory_limit_mb: 512,
+
+      local statefulSet = $.apps.v1beta1.statefulSet,
+      statefulSet+:
+        statefulSet.mixin.spec.withReplicas(1),
+    },
 }

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -42,6 +42,16 @@
     'experimental.tsdb.bucket-store.chunks-cache.memcached.max-get-multi-batch-size': '100',
   },
 
+  blocks_metadata_caching_config:: {
+    'experimental.tsdb.bucket-store.metadata-cache.backend': 'memcached',
+    'experimental.tsdb.bucket-store.metadata-cache.memcached.addresses': 'dnssrvnoa+memcached-metadata.%(namespace)s.svc.cluster.local:11211' % $._config,
+    'experimental.tsdb.bucket-store.metadata-cache.memcached.timeout': '200ms',
+    'experimental.tsdb.bucket-store.metadata-cache.memcached.max-item-size': $._config.memcached_metadata_max_item_size_mb * 1024 * 1024,
+    'experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-buffer-size': '25000',
+    'experimental.tsdb.bucket-store.metadata-cache.memcached.max-async-concurrency': '50',
+    'experimental.tsdb.bucket-store.metadata-cache.memcached.max-get-multi-batch-size': '100',
+  },
+
   // The querier should run on a dedicated volume used to sync TSDB
   // indexes, in order to not negatively affect the node performances
   // in case of sustained I/O or utilization. For this reason we:
@@ -61,7 +71,7 @@
     // is generated
     'experimental.tsdb.bucket-store.tenant-sync-concurrency': 2,
     'experimental.tsdb.bucket-store.block-sync-concurrency': 5,
-  } + (if !$._config.store_gateway_enabled then $.blocks_chunks_caching_config else {}),
+  } + $.blocks_metadata_caching_config + (if !$._config.store_gateway_enabled then $.blocks_chunks_caching_config else {}),
 
   querier_container+::
     container.withVolumeMountsMixin([
@@ -189,7 +199,7 @@
       // Persist ring tokens so that when the store-gateway will be restarted
       // it will pick the same tokens
       'experimental.store-gateway.tokens-file-path': '/data/tokens',
-    } + (if $._config.store_gateway_enabled then $.blocks_chunks_caching_config else {}),
+    } + $.blocks_chunks_caching_config + $.blocks_metadata_caching_config,
 
   store_gateway_ports:: $.util.defaultPorts,
 


### PR DESCRIPTION
Cache is used by both querier (even if store-gateway is disabled) and store-gateway.