### PR TITLE
Improved Cortex blocks compactor alerts and dashboard

### DIFF
--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -4,33 +4,33 @@
       name: 'cortex_compactor_alerts',
       rules: [
         {
-          // Alert if the compactor has not successfully completed a run in the last 24h.
-          alert: 'CortexCompactorHasNotSuccessfullyRun',
+          // Alert if the compactor has not successfully cleaned up blocks in the last 24h.
+          alert: 'CortexCompactorHasNotSuccessfullyCleanedUpBlocks',
           'for': '15m',
           expr: |||
-            (time() - cortex_compactor_last_successful_run_timestamp_seconds{%s} > 60 * 60 * 24)
+            (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds{%s} > 60 * 60 * 24)
             and
-            (cortex_compactor_last_successful_run_timestamp_seconds{%s} > 0)
+            (cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds{%s} > 0)
           ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
           labels: {
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not successfully completed a run in the last 24 hours.',
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not successfully cleaned up blocks in the last 24 hours.',
           },
         },
         {
-          // Alert if the compactor has not successfully completed a run since its start.
-          alert: 'CortexCompactorHasNotSuccessfullyRunSinceStart',
+          // Alert if the compactor has not successfully cleaned up blocks since its start.
+          alert: 'CortexCompactorHasNotSuccessfullyCleanedUpBlocksSinceStart',
           'for': '24h',
           expr: |||
-            cortex_compactor_last_successful_run_timestamp_seconds{%s} == 0
+            cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds{%s} == 0
           ||| % $.namespace_matcher(''),
           labels: {
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not successfully completed a run in the last 24 hours.',
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not successfully cleaned up blocks in the last 24 hours.',
           },
         },
         {

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -9,7 +9,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.textPanel('', |||
           - **Per-instance runs**: number of times a compactor instance triggers a compaction across all tenants its shard manage.
-          - **Per-tenant runs**: number of times a compactor instance triggers the compaction for a single tenant's blocks.
+          - **Compacted blocks**: number of blocks generated as a result of a compaction operation.
+          - **Per-block compaction duration**: time taken to generate a single compacted block.
         |||),
       )
       .addPanel(
@@ -21,24 +22,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ) +
         $.bars +
         { yaxes: $.yaxes('ops') },
-      )
-      .addPanel(
-        $.successFailurePanel(
-          'Per-tenant runs / sec',
-          'sum(rate(cortex_compactor_group_compactions_total{%s}[$__interval])) - sum(rate(cortex_compactor_group_compactions_failures_total{%s}[$__interval]))' % [$.jobMatcher('compactor'), $.jobMatcher('compactor')],
-          'sum(rate(cortex_compactor_group_compactions_failures_total{%s}[$__interval]))' % $.jobMatcher('compactor'),
-        ) +
-        $.bars +
-        { yaxes: $.yaxes('ops') },
-      )
-    )
-    .addRow(
-      $.row('')
-      .addPanel(
-        $.textPanel('', |||
-          - **Compacted blocks**: number of blocks generated as a result of a compaction operation.
-          - **Per-block compaction duration**: time taken to generate a single compacted block.
-        |||),
       )
       .addPanel(
         $.panel('Compacted blocks / sec') +


### PR DESCRIPTION
In this PR I'm proposing few changes related to the blocks compactor:
1. Dashboard: remove panel displaying "per-tenant compactions" (based on `cortex_compactor_group_compactions_*` metrics) because grouping logic is not necessarily "1 group per tenant"
2. Alert: remove alert on `cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds` because, as of today, this metric can get never updated if the compactor is always busy doing compaction. This is due to how Thanos `BucketCompactor` works (the `Compact()` function doesn't return as far as there's some work to do). I will work to propose an improvement to Thanos to have a metric there from which we can alert on.
3. Alert: add an alert if the blocks cleanup didn't successfully run (this is a recent introduction in Cortex, because it was coupled to the blocks compaction loop).

## Preview of the compactor dashboard

![Screen Shot 2020-06-04 at 17 10 34](https://user-images.githubusercontent.com/1701904/83774876-94c52d00-a686-11ea-81d7-65fcdea1cb48.png)
