### PR TITLE
refactor: remove method usage

### DIFF
--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -34,8 +34,8 @@
 
 
   alertmanager_statefulset:
-    statefulSet.new('alertmanager', 1, [$.alertmanager_container], $.alertmanager_pvc)
-    .withServiceName('alertmanager') +
+    statefulSet.new('alertmanager', 1, [$.alertmanager_container], $.alertmanager_pvc) +
+    statefulSet.mixin.spec.withServiceName('alertmanager') +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: 'alertmanager' }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: 'alertmanager' }) +

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -82,8 +82,8 @@
     ]),
 
   ingester_statefulset:
-    statefulSet.new('ingester', 3, [$.ingester_container], ingester_data_pvc)
-    .withServiceName('ingester') +
+    statefulSet.new('ingester', 3, [$.ingester_container], ingester_data_pvc) +
+    statefulSet.mixin.spec.withServiceName('ingester') +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: 'ingester' }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: 'ingester' } + $.ingester_deployment_labels) +
@@ -131,8 +131,8 @@
     $.jaeger_mixin,
 
   compactor_statefulset:
-    statefulSet.new('compactor', 1, [$.compactor_container], compactor_data_pvc)
-    .withServiceName('compactor') +
+    statefulSet.new('compactor', 1, [$.compactor_container], compactor_data_pvc) +
+    statefulSet.mixin.spec.withServiceName('compactor') +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: 'compactor' }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: 'compactor' }) +
@@ -172,8 +172,8 @@
     $.jaeger_mixin,
 
   store_gateway_statefulset:
-    statefulSet.new('store-gateway', 3, [$.store_gateway_container], store_gateway_data_pvc)
-    .withServiceName('store-gateway') +
+    statefulSet.new('store-gateway', 3, [$.store_gateway_container], store_gateway_data_pvc) +
+    statefulSet.mixin.spec.withServiceName('store-gateway') +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: 'store-gateway' }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: 'store-gateway' }) +


### PR DESCRIPTION
To allow the migration to upcoming [jsonnet-libs/k8s](https://jsonnet-libs.github.io/k8s-alpha/) library, we need to
remove the "object-oriented" usages of ksonnet-lib, as those will not be
supported anymore for performance reasons.

cortex-jsonnet didn't use a lot of those, so this is fairly small.