### PR TITLE
Fine-tune blocks storage config

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -133,8 +133,9 @@
         'store.engine': 'tsdb',
         'experimental.tsdb.dir': '/data/tsdb',
         'experimental.tsdb.bucket-store.sync-dir': '/data/tsdb',
+        'experimental.tsdb.bucket-store.ignore-deletion-marks-delay': '1h',
         'experimental.tsdb.block-ranges-period': '2h',
-        'experimental.tsdb.retention-period': '6h',
+        'experimental.tsdb.retention-period': '13h',
         'experimental.tsdb.ship-interval': '1m',
         'experimental.tsdb.backend': 'gcs',
         'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
@@ -167,11 +168,11 @@
         // Don't query the chunk store for data younger than max_chunk_idle.
         'querier.query-store-after': $._config.max_chunk_idle,
       } else if $._config.storage_engine == 'tsdb' then {
-        // Ingesters don't have data older than 6h, no need to ask them.
-        'querier.query-ingesters-within': '6h',
+        // Ingesters don't have data older than 13h, no need to ask them.
+        'querier.query-ingesters-within': '13h',
 
-        // No need to look at store for data younger than 4h, as ingesters have all of it.
-        'querier.query-store-after': '4h',
+        // No need to look at store for data younger than 12h, as ingesters have all of it.
+        'querier.query-store-after': '12h',
       }
     ) + (
       if $._config.memcached_index_queries_enabled && $._config.storage_engine == 'chunks' then

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -17,6 +17,9 @@
     // Allow to configure the compactor disk.
     cortex_compactor_data_disk_size: '250Gi',
     cortex_compactor_data_disk_class: 'standard',
+
+    // Allow to fine tune compactor.
+    cortex_compactor_max_concurrency: 1,
   },
 
   blocks_chunks_caching_config::
@@ -116,6 +119,7 @@
       'compactor.block-ranges': '2h,12h,24h',
       'compactor.data-dir': '/data',
       'compactor.compaction-interval': '30m',
+      'compactor.compaction-concurrency': $._config.cortex_compactor_max_concurrency,
     },
 
   compactor_ports:: $.util.defaultPorts,
@@ -126,7 +130,7 @@
     container.withArgsMixin($.util.mapToFlags($.compactor_args)) +
     container.withVolumeMountsMixin([volumeMount.new('compactor-data', '/data')]) +
     $.util.resourcesRequests('1', '6Gi') +
-    $.util.resourcesLimits('1', '6Gi') +
+    $.util.resourcesLimits($._config.cortex_compactor_max_concurrency, '6Gi') +
     $.util.readinessProbe +
     $.jaeger_mixin,
 


### PR DESCRIPTION
In this PR I'm backporting some settings we've seen improving read-path performances in the blocks storage, making sure non-compacted blocks are not queried.