### PR TITLE
Fix selector in querier service

### DIFF
--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -61,5 +61,5 @@
 
   querier_service:
     $.util.serviceFor($.querier_deployment, $.querier_service_ignored_labels) +
-    service.mixin.spec.withSelector({ name: 'query-frontend' }),
+    service.mixin.spec.withSelector({ name: 'querier' }),
 }


### PR DESCRIPTION
The selector should be "querier" instead of "query-frontend".
Please correct me if I'm wrong.