### PR TITLE
Added blocks storage refetch metrics and alerts

### DIFF
--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -25,12 +25,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Query Frontend - Results Cache')
       .addPanel(
         $.panel('Cache Hit %') +
-        $.queryPanel('sum(rate(cortex_cache_hits{%s}[1m])) / sum(rate(cortex_cache_fetched_keys{%s}[1m]))' % [$.jobMatcher($._config.job_names.query_frontend), $.jobMatcher($._config.job_names.query_frontend)], 'Hit Rate') +
+        $.queryPanel('sum(rate(cortex_cache_hits{name=~"frontend.+", %s}[1m])) / sum(rate(cortex_cache_fetched_keys{name=~"frontend.+", %s}[1m]))' % [$.jobMatcher($._config.job_names.query_frontend), $.jobMatcher($._config.job_names.query_frontend)], 'Hit Rate') +
         { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
       )
       .addPanel(
         $.panel('Cache misses') +
-        $.queryPanel('sum(rate(cortex_cache_fetched_keys{%s}[1m])) - sum(rate(cortex_cache_hits{%s}[1m]))' % [$.jobMatcher($._config.job_names.query_frontend), $.jobMatcher($._config.job_names.query_frontend)], 'Miss Rate'),
+        $.queryPanel('sum(rate(cortex_cache_fetched_keys{name=~"frontend.+", %s}[1m])) - sum(rate(cortex_cache_hits{name=~"frontend.+", %s}[1m]))' % [$.jobMatcher($._config.job_names.query_frontend), $.jobMatcher($._config.job_names.query_frontend)], 'Miss Rate'),
       )
     )
     .addRow(

--- a/cortex-mixin/dashboards/ruler.libsonnet
+++ b/cortex-mixin/dashboards/ruler.libsonnet
@@ -13,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           [
             |||
               sum(rate(cortex_prometheus_rule_evaluations_total{%s}[$__interval]))
-              - 
+              -
               sum(rate(cortex_prometheus_rule_evaluation_failures_total{%s}[$__interval]))
             ||| % [$.jobMatcher('ruler'), $.jobMatcher('ruler')],
             'sum(rate(cortex_prometheus_rule_evaluation_failures_total{%s}[$__interval]))' % $.jobMatcher('ruler'),

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -93,6 +93,14 @@ This alert fires when a Cortex querier is not successfully scanning blocks in th
 How to investigate:
 - Look for any scan error in the querier logs (ie. networking or rate limiting issues)
 
+## CortexQuerierHighRefetchRate
+
+This alert fires when there's an high number of queries for which series have been refetched from a different store-gateway because of missing blocks. This could happen for a short time whenever a store-gateway ring resharding occurs (e.g. during/after an outage or while rolling out store-gateway) but store-gateways should reconcile in a short time. This alert fires if the issue persist for an unexpected long time and thus it should be investigated.
+
+How to investigate:
+- Ensure there are no errors related to blocks scan or sync in the queriers and store-gateways
+- Check store-gateway logs to see if all store-gateway have successfully completed a blocks sync
+
 ## CortexStoreGatewayHasNotSyncTheBucket
 
 This alert fires when a Cortex store-gateway is not successfully scanning blocks in the storage (bucket). A store-gateway is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket for a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.


### PR DESCRIPTION
I've just merged the Cortex PR https://github.com/cortexproject/cortex/pull/2695 that introduced refetching of series from a different store-gateway in case of missing blocks (consistency check failed).

_In this PR I'm introducing some new metrics and alerts related to that change._