### PR TITLE
Run store-gateway without CPU limits

### DIFF
--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -171,7 +171,7 @@
     container.withArgsMixin($.util.mapToFlags($.store_gateway_args)) +
     container.withVolumeMountsMixin([volumeMount.new('store-gateway-data', '/data')]) +
     $.util.resourcesRequests('1', '6Gi') +
-    $.util.resourcesLimits('1', '6Gi') +
+    $.util.resourcesLimits(null, '6Gi') +
     $.util.readinessProbe +
     $.jaeger_mixin,
 


### PR DESCRIPTION
By default we're running the store-gateway with a CPU limit=1, but it should run with no CPU limit to avoid CPU throttling, basically like any other Cortex core component.