### PR TITLE
Correct alerts to work with Cortex single binary

### DIFF
--- a/cortex-mixin/alerts.jsonnet
+++ b/cortex-mixin/alerts.jsonnet
@@ -1,1 +1,3 @@
-std.manifestYamlDoc((import 'mixin.libsonnet').prometheusAlerts)
+local mixin = import 'mixin.libsonnet';
+
+std.manifestYamlDoc(mixin.prometheusAlerts)

--- a/cortex-mixin/alerts/alert-utils.libsonnet
+++ b/cortex-mixin/alerts/alert-utils.libsonnet
@@ -5,4 +5,14 @@
     if std.length($._config.alert_namespace_matcher) != 0
     then '%s namespace=~"%s"' % [prefix, $._config.alert_namespace_matcher]
     else '',
+
+  aggregation_labels(replace='')::
+    if $._config.singleBinary == true
+    then 'job'
+    else replace,
+
+  annotation_labels(replace='$labels.namespace')::
+    if $._config.singleBinary == true
+    then '$labels.job'
+    else replace,
 }

--- a/cortex-mixin/alerts/alert-utils.libsonnet
+++ b/cortex-mixin/alerts/alert-utils.libsonnet
@@ -1,8 +1,0 @@
-{
-  _config:: error 'must provide _config for alerts',
-
-  annotation_labels(replace='$labels.namespace')::
-    if $._config.singleBinary == true
-    then '$labels.job'
-    else replace,
-}

--- a/cortex-mixin/alerts/alert-utils.libsonnet
+++ b/cortex-mixin/alerts/alert-utils.libsonnet
@@ -1,16 +1,6 @@
 {
   _config:: error 'must provide _config for alerts',
 
-  namespace_matcher(prefix='')::
-    if std.length($._config.alert_namespace_matcher) != 0
-    then '%s namespace=~"%s"' % [prefix, $._config.alert_namespace_matcher]
-    else '',
-
-  aggregation_labels(replace='')::
-    if $._config.singleBinary == true
-    then 'job'
-    else replace,
-
   annotation_labels(replace='$labels.namespace')::
     if $._config.singleBinary == true
     then '$labels.job'

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -18,10 +18,12 @@
         },
         {
           alert: 'CortexRequestErrors',
+          // Note is alert_aggregation_labels is "job", this will repeat the label.  But
+          // prometheus seems to tolerate that.
           expr: |||
-            100 * sum by (%s, route) (rate(cortex_request_duration_seconds_count{status_code=~"5.."}[1m])) 
+            100 * sum by (%s, job, route) (rate(cortex_request_duration_seconds_count{status_code=~"5.."}[1m])) 
               /
-            sum y (%s, route) (rate(cortex_request_duration_seconds_count[1m])) 
+            sum y (%s, job, route) (rate(cortex_request_duration_seconds_count[1m])) 
               > 1
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '15m',
@@ -30,7 +32,7 @@
           },
           annotations: {
             message: |||
-              {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.
+              {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.
             |||,
           },
         },

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -1,4 +1,4 @@
-(import 'alert-utils.libsonnet') {
+{
   groups+: [
     {
       name: 'cortex_alerts',
@@ -23,7 +23,7 @@
               /
             sum y (%s, route) (rate(cortex_request_duration_seconds_count[1m])) 
               > 1
-          ||| % [$._config.alert_aggregation_labels],
+          ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '15m',
           labels: {
             severity: 'warning',
@@ -140,9 +140,9 @@
         {
           alert: 'CortexCacheRequestErrors',
           expr: |||
-            100 * sum by (%s, method) (rate(cortex_cache_request_duration_seconds_count{status_code=~"5.." %s}[1m])) 
+            100 * sum by (%s, method) (rate(cortex_cache_request_duration_seconds_count{status_code=~"5.."}[1m])) 
               /
-            sum  by (%s, method) (rate(cortex_cache_request_duration_seconds_count{%s}[1m]))
+            sum  by (%s, method) (rate(cortex_cache_request_duration_seconds_count[1m]))
               > 1
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '15m',
@@ -306,8 +306,8 @@
           },
           annotations: {
             message: |||
-              Chunk memcached cluster for {{ %s }} are too small, should be at least {{ printf "%.2f" $value }}GB.
-            ||| % $.annotation_labels(),
+              Chunk memcached cluster is too small, should be at least {{ printf "%.2f" $value }}GB.
+            |||,
           },
         },
         {
@@ -324,8 +324,8 @@
           },
           annotations: {
             message: |||
-              Too many active series for ingesters in {{ %s }}, add more ingesters.
-            ||| % $.annotation_labels(),
+              Too many active series for ingesters, add more ingesters.
+            |||,
           },
         },
         {
@@ -340,8 +340,8 @@
           },
           annotations: {
             message: |||
-              High QPS for ingesters in {{ %s }}, add more ingesters.
-            ||| % $.annotation_labels(),
+              High QPS for ingesters, add more ingesters.
+            |||,
           },
         },
         {

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -289,7 +289,7 @@
             (
               sum by(%s) (memcached_limit_bytes{job=~".+/memcached"}) / 1e9
             )
-          ||| % $.aggregation_labels('cluster, namespace'),
+          ||| % [$.aggregation_labels('cluster, namespace'), $.aggregation_labels('cluster, namespace')],
           'for': '15m',
           labels: {
             severity: 'warning',
@@ -307,7 +307,7 @@
             avg by (%s) (cortex_ingester_memory_series) > 1.1e6
               and
             sum by (%s) (rate(cortex_ingester_received_chunks[1h])) == 0
-          ||| % $.aggregation_labels('cluster, namespace'),
+          ||| % [$.aggregation_labels('cluster, namespace'), $.aggregation_labels('cluster, namespace')],
           'for': '1h',
           labels: {
             severity: 'warning',
@@ -417,7 +417,7 @@
             memberlist_client_cluster_members_count{%s}
               != on (%s) group_left
             sum(up{job=~".+/(distributor|ingester|querier|cortex|ruler)"}) by (%s)
-          ||| % [$.namespace_matcher(), $.aggregation_labels('namespace, job'), $.aggregation_labels('namespace, job')],
+          ||| % [$.namespace_matcher(), $.aggregation_labels('cluster, namespace'), $.aggregation_labels('cluster, namespace')],
           'for': '5m',
           labels: {
             severity: 'warning',

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -23,7 +23,7 @@
           expr: |||
             100 * sum by (%s, job, route) (rate(cortex_request_duration_seconds_count{status_code=~"5.."}[1m])) 
               /
-            sum y (%s, job, route) (rate(cortex_request_duration_seconds_count[1m])) 
+            sum by (%s, job, route) (rate(cortex_request_duration_seconds_count[1m])) 
               > 1
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '15m',

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -40,7 +40,7 @@
           expr: |||
             (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds > 60 * 30)
             and
-            cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 0
+            cortex_querier_blocks_last_successful_scan_timestamp_seconds > 0
           |||,
           labels: {
             severity: 'critical',

--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -1,4 +1,4 @@
-(import 'alert-utils.libsonnet') {
+{
   groups+: [
     {
       name: 'cortex_blocks_alerts',
@@ -8,10 +8,10 @@
           alert: 'CortexIngesterHasNotShippedBlocks',
           'for': '15m',
           expr: |||
-            (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"%s} > 60 * 60 * 4)
+            (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"} > 60 * 60 * 4)
             and
-            (thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"%s} > 0)
-          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+            (thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"} > 0)
+          |||,
           labels: {
             severity: 'critical',
           },
@@ -24,8 +24,8 @@
           alert: 'CortexIngesterHasNotShippedBlocksSinceStart',
           'for': '4h',
           expr: |||
-            thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"%s} == 0
-          ||| % $.namespace_matcher(','),
+            thanos_objstore_bucket_last_successful_upload_time{job=~".+/ingester"} == 0
+          |||,
           labels: {
             severity: 'critical',
           },
@@ -38,10 +38,10 @@
           alert: 'CortexQuerierHasNotScanTheBucket',
           'for': '5m',
           expr: |||
-            (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 60 * 30)
+            (time() - cortex_querier_blocks_last_successful_scan_timestamp_seconds > 60 * 30)
             and
             cortex_querier_blocks_last_successful_scan_timestamp_seconds{%s} > 0
-          ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
+          |||,
           labels: {
             severity: 'critical',
           },
@@ -57,15 +57,15 @@
           expr: |||
             100 * (
               (
-                sum by(namespace) (rate(cortex_querier_storegateway_refetches_per_query_count{%s}[5m]))
+                sum by(namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
                 -
-                sum by(namespace) (rate(cortex_querier_storegateway_refetches_per_query_bucket{le="0" %s}[5m]))
+                sum by(namespace) (rate(cortex_querier_storegateway_refetches_per_query_bucket{le="0"}[5m]))
               )
               /
-              sum by(namespace) (rate(cortex_querier_storegateway_refetches_per_query_count{%s}[5m]))
+              sum by(namespace) (rate(cortex_querier_storegateway_refetches_per_query_count[5m]))
             )
             > 1
-          ||| % [$.namespace_matcher(''), $.namespace_matcher(','), $.namespace_matcher('')],
+          |||,
           labels: {
             severity: 'warning',
           },
@@ -78,10 +78,10 @@
           alert: 'CortexStoreGatewayHasNotSyncTheBucket',
           'for': '5m',
           expr: |||
-            (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway",%s} > 60 * 30)
+            (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
             and
-            cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway",%s} > 0
-          ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
+            cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 0
+          |||,
           labels: {
             severity: 'critical',
           },

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -1,4 +1,4 @@
-(import 'alert-utils.libsonnet') {
+{
   groups+: [
     {
       name: 'cortex_compactor_alerts',
@@ -8,10 +8,10 @@
           alert: 'CortexCompactorHasNotSuccessfullyCleanedUpBlocks',
           'for': '15m',
           expr: |||
-            (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds{%s} > 60 * 60 * 24)
+            (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 60 * 60 * 24)
             and
-            (cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds{%s} > 0)
-          ||| % [$.namespace_matcher(''), $.namespace_matcher('')],
+            (cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 0)
+          |||,
           labels: {
             severity: 'critical',
           },
@@ -24,8 +24,8 @@
           alert: 'CortexCompactorHasNotSuccessfullyCleanedUpBlocksSinceStart',
           'for': '24h',
           expr: |||
-            cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds{%s} == 0
-          ||| % $.namespace_matcher(''),
+            cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds == 0
+          |||,
           labels: {
             severity: 'critical',
           },
@@ -38,10 +38,10 @@
           alert: 'CortexCompactorHasNotUploadedBlocks',
           'for': '15m',
           expr: |||
-            (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 60 * 60 * 24)
+            (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"} > 60 * 60 * 24)
             and
             (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 0)
-          ||| % [$.namespace_matcher(','), $.namespace_matcher(',')],
+          |||,
           labels: {
             severity: 'critical',
           },
@@ -54,8 +54,8 @@
           alert: 'CortexCompactorHasNotUploadedBlocksSinceStart',
           'for': '24h',
           expr: |||
-            thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} == 0
-          ||| % $.namespace_matcher(','),
+            thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"} == 0
+          |||,
           labels: {
             severity: 'critical',
           },

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -40,7 +40,7 @@
           expr: |||
             (time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"} > 60 * 60 * 24)
             and
-            (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"%s} > 0)
+            (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor"} > 0)
           |||,
           labels: {
             severity: 'critical',

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,8 +33,10 @@
       gateway: 'cortex-gw',
     },
 
+    // Labels used to in alert aggregations - should uniquely identify
+    // a single Cortex cluster.
+    alert_aggregation_labels: 'cluster, namespace',
     cortex_p99_latency_threshold_seconds: 2.5,
-    alert_namespace_matcher: '',
 
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
     resources_dashboards_enabled: false,


### PR DESCRIPTION
Builds on https://github.com/grafana/cortex-jsonnet/pull/102; opening a new PR to the the CI working.

Some big changes here:
- Specify the labels which can be used to get aggregate per-cluster metrics.  Ie for our deployments, those labels would be `(cluster, namespace)` but for a single-binary setup it would be `(job)`.
- Don't bother with functions, we just need to know a list of labels to aggregate by that will identify a single Cortex cluster (ie "cluster, namespace" or "job").
- Remove alert_namespace_matcher, its brittle and hard to maintain.
- Put WAL alerts in a separate group.
- Remove `CortexFlushStuck`, its been superseded by **CortexOldChunkInMemory**