### PR TITLE
Use v1 API for Deployment and StatefulSet resources

### DIFF
--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -2,7 +2,7 @@
   local pvc = $.core.v1.persistentVolumeClaim,
   local volumeMount = $.core.v1.volumeMount,
   local container = $.core.v1.container,
-  local statefulSet = $.apps.v1beta1.statefulSet,
+  local statefulSet = $.apps.v1.statefulSet,
   local service = $.core.v1.service,
 
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -332,7 +332,7 @@
       }),
     }),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
   storage_config_mixin::
     deployment.mixin.spec.template.metadata.withAnnotationsMixin({ schemaID: $._config.schemaID },) +
     $.util.configVolumeMount('schema-' + $._config.schemaID, '/etc/cortex/schema'),

--- a/cortex/consul.libsonnet
+++ b/cortex/consul.libsonnet
@@ -26,7 +26,7 @@ local consul = import 'consul/consul.libsonnet';
       ]) +
       $.util.resourcesRequests('4', '4Gi'),
 
-    local deployment = $.apps.v1beta1.deployment,
+    local deployment = $.apps.v1.deployment,
     local podAntiAffinity = deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
     local volume = $.core.v1.volume,
     consul_deployment+:

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -48,7 +48,7 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   distributor_deployment_labels:: {},
 

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -52,7 +52,7 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   ingester_deployment_labels:: {},
 

--- a/cortex/memcached.libsonnet
+++ b/cortex/memcached.libsonnet
@@ -6,7 +6,7 @@ memcached {
 
     deployment: {},
 
-    local statefulSet = $.apps.v1beta1.statefulSet,
+    local statefulSet = $.apps.v1.statefulSet,
 
     statefulSet:
       statefulSet.new(self.name, 3, [
@@ -72,7 +72,7 @@ memcached {
       // Metadata cache doesn't need much memory.
       memory_limit_mb: 512,
 
-      local statefulSet = $.apps.v1beta1.statefulSet,
+      local statefulSet = $.apps.v1.statefulSet,
       statefulSet+:
         statefulSet.mixin.spec.withReplicas(1),
     },

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -45,7 +45,7 @@
       $.util.resourcesRequests('1', '12Gi') +
       $.util.resourcesLimits(null, '24Gi'),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   querier_deployment_labels: {},
 

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -61,7 +61,7 @@
       $.util.resourcesRequests('2', '600Mi') +
       $.util.resourcesLimits(null, '1200Mi'),
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   query_frontend_deployment:
     deployment.new('query-frontend', $._config.queryFrontend.replicas, [$.query_frontend_container]) +

--- a/cortex/query-tee.libsonnet
+++ b/cortex/query-tee.libsonnet
@@ -1,7 +1,7 @@
 {
   local container = $.core.v1.container,
   local containerPort = $.core.v1.containerPort,
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
   local service = $.core.v1.service,
   local servicePort = $.core.v1.servicePort,
 

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -28,7 +28,7 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   ruler_deployment:
     deployment.new('ruler', 2, [$.ruler_container]) +

--- a/cortex/table-manager.libsonnet
+++ b/cortex/table-manager.libsonnet
@@ -29,7 +29,7 @@
       $.jaeger_mixin
     else {},
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   table_manager_deployment:
     if $._config.table_manager_enabled then

--- a/cortex/test-exporter.libsonnet
+++ b/cortex/test-exporter.libsonnet
@@ -22,7 +22,7 @@
       $.util.resourcesLimits('100m', '100Mi') +
       $.jaeger_mixin,
 
-  local deployment = $.apps.v1beta1.deployment,
+  local deployment = $.apps.v1.deployment,
 
   test_exporter_deployment:
     if !($._config.test_exporter_enabled)

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -2,7 +2,7 @@
   local pvc = $.core.v1.persistentVolumeClaim,
   local volumeMount = $.core.v1.volumeMount,
   local container = $.core.v1.container,
-  local statefulSet = $.apps.v1beta1.statefulSet,
+  local statefulSet = $.apps.v1.statefulSet,
   local service = $.core.v1.service,
 
   _config+:: {


### PR DESCRIPTION
AFAICT, there's no reason for these to be stuck to the `apps/v1beta1` API version. Note that I kept the `v1beta1` version for the `PodDisruptionBudget` that gets created.