### PR TITLE
Added ruler_enabled and alertmanager_enabled flags.

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -203,6 +203,7 @@
       'ring.heartbeat-timeout': '10m',
     },
 
+    ruler_enabled: false,
     ruler_client_type: error 'you must specify a storage backend type for the ruler (azure, configdb, gcs, s3)',
     // TODO: Generic client generating functions would be nice.
     ruler_s3_bucket_name: $._config.s3_bucket_name,
@@ -308,6 +309,8 @@
     schemaID: std.md5(std.toString($._config.schema)),
 
     enable_pod_priorities: true,
+
+    alertmanager_enabled: false,
   },
 
   local configMap = $.core.v1.configMap,

--- a/cortex/cortex.libsonnet
+++ b/cortex/cortex.libsonnet
@@ -12,6 +12,7 @@
 (import 'query-frontend.libsonnet') +
 (import 'table-manager.libsonnet') +
 (import 'ruler.libsonnet') +
+(import 'alertmanager.libsonnet') +
 
 // Supporting services
 (import 'etcd.libsonnet') +

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -20,25 +20,31 @@
     },
 
   ruler_container::
-    container.new('ruler', $._images.ruler) +
-    container.withPorts($.util.defaultPorts) +
-    container.withArgsMixin($.util.mapToFlags($.ruler_args)) +
-    $.util.resourcesRequests('1', '6Gi') +
-    $.util.resourcesLimits('16', '16Gi') +
-    $.util.readinessProbe +
-    $.jaeger_mixin,
+    if $._config.ruler_enabled then
+      container.new('ruler', $._images.ruler) +
+      container.withPorts($.util.defaultPorts) +
+      container.withArgsMixin($.util.mapToFlags($.ruler_args)) +
+      $.util.resourcesRequests('1', '6Gi') +
+      $.util.resourcesLimits('16', '16Gi') +
+      $.util.readinessProbe +
+      $.jaeger_mixin
+    else {},
 
   local deployment = $.apps.v1.deployment,
 
   ruler_deployment:
-    deployment.new('ruler', 2, [$.ruler_container]) +
-    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
-    $.util.antiAffinity +
-    $.util.configVolumeMount('overrides', '/etc/cortex') +
-    $.storage_config_mixin,
+    if $._config.ruler_enabled then
+      deployment.new('ruler', 2, [$.ruler_container]) +
+      deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
+      $.util.antiAffinity +
+      $.util.configVolumeMount('overrides', '/etc/cortex') +
+      $.storage_config_mixin
+    else {},
 
   local service = $.core.v1.service,
 
   ruler_service:
-    $.util.serviceFor($.ruler_deployment),
+    if $._config.ruler_enabled then
+      $.util.serviceFor($.ruler_deployment)
+    else {},
 }


### PR DESCRIPTION
In [recent commit](https://github.com/grafana/cortex-jsonnet/commit/f282f10524978bc20cdb8b56753ce54d0aa1a9a9) ruler has been included by default, so we need a flag to disable it.

At the same time, added a flag to disable alertmanager and include its jsonnet file by default too.
