### PR TITLE
Added publish not ready addresses

### DIFF
--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -19,7 +19,7 @@
 
       // Limit to N/2 worker threads per frontend, as we have two frontends.
       'querier.worker-parallelism': $._config.querier.concurrency / $._config.queryFrontend.replicas,
-      'querier.frontend-address': 'query-frontend.%(namespace)s.svc.cluster.local:9095' % $._config,
+      'querier.frontend-address': 'query-frontend-discovery.%(namespace)s.svc.cluster.local:9095' % $._config,
       'querier.frontend-client.grpc-max-send-msg-size': 100 << 20,
 
       'log.level': 'debug',
@@ -57,9 +57,6 @@
 
   local service = $.core.v1.service,
 
-  querier_service_ignored_labels:: [],
-
   querier_service:
-    $.util.serviceFor($.querier_deployment, $.querier_service_ignored_labels) +
-    service.mixin.spec.withSelector({ name: 'query-frontend' }),
+    $.util.serviceFor($.querier_deployment),
 }

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -85,5 +85,5 @@
     // returns the set of query-frontend IPs.
     service.mixin.spec.withPublishNotReadyAddresses(true) +
     service.mixin.spec.withClusterIp('None') +
-    service.mixin.metadata.withName('query-frontend-discovery')
+    service.mixin.metadata.withName('query-frontend-discovery'),
 }

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -80,5 +80,6 @@
     // each query-frontend pod IP and NOT the service IP. To make it, we do NOT
     // use the service cluster IP so that when the service DNS is resolved it
     // returns the set of query-frontend IPs.
+    service.mixin.spec.withPublishNotReadyAddresses(true) +
     service.mixin.spec.withClusterIp('None'),
 }

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -75,11 +75,15 @@
   local service = $.core.v1.service,
 
   query_frontend_service:
+    $.util.serviceFor($.query_frontend_deployment),
+
+  query_frontend_discovery_service:
     $.util.serviceFor($.query_frontend_deployment) +
     // Make sure that query frontend worker, running in the querier, do resolve
     // each query-frontend pod IP and NOT the service IP. To make it, we do NOT
     // use the service cluster IP so that when the service DNS is resolved it
     // returns the set of query-frontend IPs.
     service.mixin.spec.withPublishNotReadyAddresses(true) +
-    service.mixin.spec.withClusterIp('None'),
+    service.mixin.spec.withClusterIp('None') +
+    service.mixin.metadata.withName('query-frontend-discovery')
 }


### PR DESCRIPTION
Due to these changes https://github.com/cortexproject/cortex/pull/2733 we need to make adjustments to the way we configure our query frontend service.

Currently the queriers use the headless `query-frontend` service to discover frontends.  After the above change frontends will no longer be included in this service until their readiness probe returns 200.  This change will cause k8s to include query frontends in the `query-frontend` service that are not yet ready.  This will allow queriers to find them successfully.

This change can be rolled out before or alongside the reference cortex change.