### PR TITLE
Added compactor to memberlist client

### DIFF
--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -432,7 +432,7 @@
           expr: |||
             memberlist_client_cluster_members_count
               != on (%s) group_left
-            sum by (%s) (up{job=~".+/(distributor|ingester|querier|cortex|ruler)"})
+            sum by (%s) (up{job=~".+/(distributor|ingester|querier|cortex|ruler|compactor)"})
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '5m',
           labels: {


### PR DESCRIPTION
This is causing alerts for other elements of our infrastructure that happen to publish this metric as well.  The proposed change is odd, but would technically fix the issue for us.

@pstibrany I'm not super familiar with these alerts is there a better fix here?  Perhaps a way to add a filter to the alert or maybe prefix the `memberlist_` metrics for my application?

