### PR TITLE
Removed -experimental.tsdb.store-gateway-enabled flag

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -139,7 +139,6 @@
         'experimental.tsdb.ship-interval': '1m',
         'experimental.tsdb.backend': 'gcs',
         'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
-        'experimental.tsdb.store-gateway-enabled': true,
         'experimental.store-gateway.sharding-enabled': true,
         'experimental.store-gateway.sharding-ring.store': 'consul',
         'experimental.store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,


### PR DESCRIPTION
The Cortex PR https://github.com/cortexproject/cortex/pull/2822 removes `-experimental.tsdb.store-gateway-enabled`: the new Cortex behaviour is having store-gateway always enabled (when using the blocks storage), which is what we were already doing in the mixin so in this PR I've just removed the flag.

This PR will be merged once Cortex PR is merged and we're ready to rollout.