### PR TITLE
Add store-gateway pod disruption budget

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -60,6 +60,8 @@
     storage_engine: 'chunks',
     storage_tsdb_bucket_name: error 'must specify GCS bucket name to store TSDB blocks',
 
+    store_gateway_replication_factor: 3,
+
     // TSDB storage engine doesn't require the table manager.
     table_manager_enabled: $._config.storage_engine != 'tsdb',
 
@@ -144,7 +146,7 @@
         'experimental.store-gateway.sharding-ring.store': 'consul',
         'experimental.store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
         'experimental.store-gateway.sharding-ring.prefix': '',
-        'experimental.store-gateway.replication-factor': 3,
+        'experimental.store-gateway.replication-factor': $._config.store_gateway_replication_factor,
       }
     ),
 

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -188,4 +188,13 @@
 
   store_gateway_service:
     $.util.serviceFor($.store_gateway_statefulset),
+
+  local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
+
+  store_gateway_pdb:
+    podDisruptionBudget.new() +
+    podDisruptionBudget.mixin.metadata.withName('store-gateway-pdb') +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: 'store-gateway-pdb' }) +
+    podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: 'store-gateway' }) +
+    podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
 }

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -196,5 +196,7 @@
     podDisruptionBudget.mixin.metadata.withName('store-gateway-pdb') +
     podDisruptionBudget.mixin.metadata.withLabels({ name: 'store-gateway-pdb' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: 'store-gateway' }) +
-    podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
+    // To avoid any disruption in the read path we need at least 1 replica of each
+    // block available, so the disruption budget depends on the blocks replication factor.
+    podDisruptionBudget.mixin.spec.withMaxUnavailable(if $._config.store_gateway_replication_factor > 1 then $._config.store_gateway_replication_factor - 1 else 1),
 }


### PR DESCRIPTION
Similarly to ingesters, I'm proposing to add a PodDisruptionBudget for store-gateway. The reason is that without a PDB the node autoscaler could terminate multiple store-gateways at once and thus leading to a situation where some blocks are not loaded by any store-gateway (I've seen it once in one of our envs).