### PR TITLE
Switch store-gateway StatefulSets to Parallel Pod Management

### DIFF
--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -184,7 +184,12 @@
     statefulSet.mixin.spec.selector.withMatchLabels({ name: 'store-gateway' }) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120),
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
+    // Parallelly scale up/down store-gateway instances instead of starting them
+    // one by one. This does NOT affect rolling updates: they will continue to be
+    // rolled out one by one (the next pod will be rolled out once the previous is
+    // ready).
+    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
 
   store_gateway_service:
     $.util.serviceFor($.store_gateway_statefulset),


### PR DESCRIPTION
StatefulSets support two [pod management policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies):
- `OrderedReady` (default)
- `Parallel`

When using `Parallel` rolling updates are still managed 1-by-1 (like `OrderedReady`) but scale up/down are parallel. This means that in the event of a cluster cold start, store-gateway instances can be started all at once instead of waiting 1-by-1.

I've done several manual tests in our test cluster and `Parallel` looks working fine. Manual tests done:
- Cold start: instances are started all at once
- Scale up/down > 1 instances at a time: instances are started/terminated all at once
- Rolling update: instances are rolled out 1-by-1

**IMPORTANT**: the pod management policy is one of these settings that **cannot** be changed to an existing StatefulSet. This means that to apply these changes the StatefulSet must be deleted and re-created, causing a (short) outage in the read path. Considering the blocks storage is not production ready yet, I would suggest to fix this pod management policy now instead of living with some unwanted legacy.