### PR TITLE
Cortex Ruler alerts improvements

### DIFF
--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -468,7 +468,7 @@
           },
           annotations: {
             message: |||
-              {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
+              Cortex Ruler {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
             |||,
           },
         },

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -399,6 +399,9 @@
           message: |||
             {{ printf "%.1f" $value }}% minimum errors while sending alerts from the Cortex Ruler {{$labels.instance}} to any Alertmanager.
           |||,
+          annotations: {
+            summary: 'Cortex Ruler has encountered more than 3% errors sending alerts to a any Alertmanager.',
+          },
         },
         {
           alert: 'CortexRulerErrorSendingAlertsToSomeAlertmanagers',
@@ -418,6 +421,9 @@
           message: |||
             {{ printf "%.1f" $value }}% minimum errors while sending alerts from the Cortex Ruler {{$labels.instance}} to Alertmanager {{ $labels.alertmanager }}.
           |||,
+          annotations: {
+            summary: 'Cortex Ruler has encountered more than 1% errors sending alerts to a specific Alertmanager.',
+          },
         },
         {
           alert: 'CortexRulerNotificationQueueRunningFull',
@@ -433,8 +439,11 @@
             severity: 'warning',
           },
           message: |||
-            Alert notification queue of Cortex Ruler {{$labels.instance}} is running full.
+            Alert notification queue of Cortex Ruler {{$labels.instance}} might run full, please investigate.
           |||,
+          annotations: {
+            summary: 'Cortex Ruler instance alert notification queue predicted to run full in 30m.',
+          },
         },
         {
           alert: 'CortexRulerFailedEvaluations',


### PR DESCRIPTION
Adds a set of improvements on the Cortex Ruler alerts.

The addition of:

- `CortexRulerNotConnectedToAlertmanagers` to know whenever a ruler is
  connected to _any_ Alertmanager.
- `CortexRulerErrorSendingAlertsToAnyAlertmanager` to have a threshold for sending to at least _an_ Alertmanager.
- `CortexRulerErrorSendingAlertsToSomeAlertmanagers` to have a threshold
  for sending to each alertmanager.
- `CortexRulerNotificationQueueRunningFull` to know whenever the
  notification queue will be full.

On top of that, I have modified the existing rule evaluation alerts to
include in the aggregation the instance and rule group. Given that the
ruler shards by rule group this makes it easier to identify the
offending rules.

Signed-off-by: gotjosh <josue@grafana.com>