### PR TITLE
Ruler should use metadata cache as well, if configured.

### DIFF
--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -57,6 +57,7 @@
   } else {},
 
   querier_args+:: $.blocks_metadata_caching_config,
+  ruler_args+:: $.blocks_metadata_caching_config,
 
   // The ingesters should persist TSDB blocks and WAL on a persistent
   // volume in order to be crash resilient.


### PR DESCRIPTION
Ruler instantiates querier internally, so it can use metadata cache.