### PR TITLE
readme: Fixed formatting and added `tk export` example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,48 +6,53 @@ To generate the YAMLs for deploying Cortex:
 
 1. Make sure you have tanka and jb installed:
 
-Follow the steps at https://tanka.dev/install. If you have `go` installed locally you can also use:
+    Follow the steps at https://tanka.dev/install. If you have `go` installed locally you can also use:
 
-```
-# make sure to be outside of GOPATH or a go.mod project
-$ GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
-$ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-```
+    ```
+    # make sure to be outside of GOPATH or a go.mod project
+    $ GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
+    $ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+    ```
 
-2. Initialise the application and download the cortex jsonnet lib.
+1. Initialise the application and download the cortex jsonnet lib.
 
-```
-$ mkdir <name> && cd <name>
-$ tk init
-$ jb install github.com/grafana/cortex-jsonnet/cortex
-```
+    ```
+    $ mkdir <name> && cd <name>
+    $ tk init
+    $ jb install github.com/grafana/cortex-jsonnet/cortex
+    ```
+1. Use the example monitoring.jsonnet.example:
 
-3. Use the example monitoring.jsonnet.example:
+    ```
+    $ cp vendor/cortex/cortex-manifests.jsonnet.example environments/default/main.jsonnet
+    ```
 
-```
-$ cp vendor/cortex/cortex-manifests.jsonnet.example environments/default/main.jsonnet
-```
+1. Check what is in the example:
 
-4. Check what is in the example:
+    ```
+    $ cat environments/default/main.jsonnet
+    ...
+    ```
 
-```
-$ cat environments/default/main.jsonnet
-....
-```
+1. Generate the YAML manifests:
 
-5. Generate the YAML manifests:
+    ```
+    $ tk show environments/default
+    ```
 
-```
-$ tk show environments/default
-```
+    To output YAML manifests to `./manifests`, run:
 
-To generate the dashboards and alerts for Cortex:
+    ```
+    $ tk export environments/default manifests
+    ```
 
-```
-$ cd cortex-mixin
-$ jb install
-$ mkdir out
-$ jsonnet -S alerts.jsonnet > out/alerts.yaml
-$ jsonnet -J vendor -S dashboards.jsonnet -m out
-$ jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml
-```
+    To generate the dashboards and alerts for Cortex:
+
+    ```
+    $ cd cortex-mixin
+    $ jb install
+    $ mkdir out
+    $ jsonnet -S alerts.jsonnet > out/alerts.yaml
+    $ jsonnet -J vendor -S dashboards.jsonnet -m out
+    $ jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml
+    ```


### PR DESCRIPTION
Fixed the formatting to use proper listing markdown.
Also added an example for exporting the YAML manifests to disk.