### PR TITLE
Add support for TSDB on AWS

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -5,7 +5,7 @@
     replication_factor: 3,
     external_url: error 'must define external url for cluster',
 
-    storage_backend: error 'must specify storage backend (cassandra, gcp)',
+    storage_backend: error 'must specify storage backend (cassandra, gcp, aws)',
     table_prefix: $._config.namespace,
     cassandra_addresses: error 'must specify cassandra addresses',
     bigtable_instance: error 'must specify bigtable instance',
@@ -58,7 +58,7 @@
     // Use the Cortex chunks storage engine by default, while giving the ability
     // to switch to tsdb storage.
     storage_engine: 'chunks',
-    storage_tsdb_bucket_name: error 'must specify GCS bucket name to store TSDB blocks',
+    storage_tsdb_bucket_name: error 'must specify bucket name to store TSDB blocks',
 
     store_gateway_replication_factor: 3,
 
@@ -139,8 +139,6 @@
         'experimental.tsdb.block-ranges-period': '2h',
         'experimental.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
         'experimental.tsdb.ship-interval': '1m',
-        'experimental.tsdb.backend': 'gcs',
-        'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
         'experimental.tsdb.store-gateway-enabled': true,
         'experimental.store-gateway.sharding-enabled': true,
         'experimental.store-gateway.sharding-ring.store': 'consul',
@@ -148,6 +146,14 @@
         'experimental.store-gateway.sharding-ring.prefix': '',
         'experimental.store-gateway.replication-factor': $._config.store_gateway_replication_factor,
       }
+    ) + (
+      if $._config.storage_backend == 'aws' then {
+        'experimental.tsdb.backend': 's3',
+        'experimental.tsdb.s3.bucket-name': $._config.storage_tsdb_bucket_name,
+      } else if $._config.storage_backend == 'gcs' then {
+        'experimental.tsdb.backend': 'gcs',
+        'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
+      } else {}
     ),
 
     // Shared between the Ruler and Querier

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -60,7 +60,7 @@
     storage_engine: 'chunks',
     storage_tsdb_bucket_name: error 'must specify bucket name to store TSDB blocks',
     storage_tsdb_s3_endpoint: error 'must specify S3 endpoint for TSDB blocks, like "s3.us-east-1.amazonaws.com"',
-    
+
     // Secondary storage engine is only used for querying.
     querier_second_storage_engine: null,
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -59,6 +59,7 @@
     // to switch to tsdb storage.
     storage_engine: 'chunks',
     storage_tsdb_bucket_name: error 'must specify bucket name to store TSDB blocks',
+    storage_tsdb_s3_endpoint: error 'must specify S3 endpoint for TSDB blocks, like "s3.us-east-1.amazonaws.com"',
 
     store_gateway_replication_factor: 3,
 
@@ -147,10 +148,11 @@
         'experimental.store-gateway.replication-factor': $._config.store_gateway_replication_factor,
       }
     ) + (
-      if $._config.storage_backend == 'aws' then {
+      if std.count($._config.enabledBackends, 'aws') > 0 then {
         'experimental.tsdb.backend': 's3',
         'experimental.tsdb.s3.bucket-name': $._config.storage_tsdb_bucket_name,
-      } else if $._config.storage_backend == 'gcs' then {
+        'experimental.tsdb.s3.endpoint': $._config.storage_tsdb_s3_endpoint,
+      } else if std.count($._config.enabledBackends, 'gcp') > 0 then {
         'experimental.tsdb.backend': 'gcs',
         'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
       } else {}


### PR DESCRIPTION
Currently, setting `storage_engine` to 'tsdb' assumes the use of GCS. Make it possible to use AWS instead.