### PR TITLE
Version bump to 1.2.0

### DIFF
--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -5,7 +5,7 @@
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.
-    cortex: 'cortexproject/cortex:v1.1.0',
+    cortex: 'cortexproject/cortex:v1.2.0',
 
     distributor: self.cortex,
     ingester: self.cortex,


### PR DESCRIPTION
This version is actually required for a bunch of the recently-added memcached-related configs, like `experimental.tsdb.bucket-store.metadata-cache.backend`. They don't exist in v1.1.0.