### PR TITLE
Switch blocks ingesters to parallel pod management policy

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -137,7 +137,7 @@
         'experimental.tsdb.bucket-store.sync-dir': '/data/tsdb',
         'experimental.tsdb.bucket-store.ignore-deletion-marks-delay': '1h',
         'experimental.tsdb.block-ranges-period': '2h',
-        'experimental.tsdb.retention-period': '13h',
+        'experimental.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
         'experimental.tsdb.ship-interval': '1m',
         'experimental.tsdb.backend': 'gcs',
         'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -101,7 +101,12 @@
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.util.podPriority('high') +
-    $.util.antiAffinity,
+    $.util.antiAffinity +
+    // Parallelly scale up/down store-gateway instances instead of starting them
+    // one by one. This does NOT affect rolling updates: they will continue to be
+    // rolled out one by one (the next pod will be rolled out once the previous is
+    // ready).
+    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
 
   ingester_service:
     $.util.serviceFor($.ingester_statefulset, $.ingester_service_ignored_labels),

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -102,7 +102,7 @@
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.util.podPriority('high') +
     $.util.antiAffinity +
-    // Parallelly scale up/down store-gateway instances instead of starting them
+    // Parallelly scale up/down ingester instances instead of starting them
     // one by one. This does NOT affect rolling updates: they will continue to be
     // rolled out one by one (the next pod will be rolled out once the previous is
     // ready).


### PR DESCRIPTION
Last week we had an outage in one of our staging environments running the Cortex blocks storage. Among the lessons learned, we're proposing two improvements:
1. Switch ingesters pod management policy to `Parallel` (like we already did for the store-gateways), to allow a faster scale up or cluster cold start
2. Increase the blocks retention in the ingesters from 13h to 4d, to have a longer time to protect from cases where blocks are not shipped from ingesters to storage (for any reason)

**Upgrade path**: if you're already running the blocks storage based on this mixin, you have two options to upgrade after this PR is merged:
a. Delete your ingester statefulset and re-create it (because the pod management policy can't be changed on a existing statefulset)
b. Override the pod management policy in your setup and get back to the previous setting, which was `OrderedReady`