### PR TITLE
Improved blocks storage ingester alerts

### DIFF
--- a/cortex-mixin/alerts/blocks.libsonnet
+++ b/cortex-mixin/alerts/blocks.libsonnet
@@ -40,8 +40,9 @@
           },
         },
         {
-          // Alert if the ingester is failing to compact TSDB head into a block, for any opened TSDB. This is a critical
-          // condition that should never happen.
+          // Alert if the ingester is failing to compact TSDB head into a block, for any opened TSDB. Once the TSDB head is
+          // compactable, the ingester will try to compact it every 1 minute. Repeatedly failing it is a critical condition
+          // that should never happen.
           alert: 'CortexIngesterTSDBHeadCompactionFailed',
           'for': '15m',
           expr: |||

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -95,6 +95,13 @@ If the ingester hit the disk capacity, any attempt to append samples will fail. 
 
 Same as [`CortexIngesterHasNotShippedBlocks`](#CortexIngesterHasNotShippedBlocks).
 
+## CortexIngesterTSDBHeadCompactionFailed
+
+This alert fires when a Cortex ingester is failing to compact the TSDB head into a block. A TSDB instance is opened for each tenant writing at least 1 series to the ingester and its head contains the in-memory series not flushed to a block yet. If the TSDB head compaction fails it means it's failing to compact a block from the in-memory series for at least 1 tenant.
+
+How to investigate:
+- Look for details in the ingester logs
+
 ## CortexQuerierHasNotScanTheBucket
 
 This alert fires when a Cortex querier is not successfully scanning blocks in the storage (bucket). A querier is expected to periodically iterate the bucket to find new and deleted blocks (defaults to every 5m) and if it's not successfully synching the bucket since a long time, it may end up querying only a subset of blocks, thus leading to potentially partial results.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -97,7 +97,9 @@ Same as [`CortexIngesterHasNotShippedBlocks`](#CortexIngesterHasNotShippedBlocks
 
 ## CortexIngesterTSDBHeadCompactionFailed
 
-This alert fires when a Cortex ingester is failing to compact the TSDB head into a block. A TSDB instance is opened for each tenant writing at least 1 series to the ingester and its head contains the in-memory series not flushed to a block yet. If the TSDB head compaction fails it means it's failing to compact a block from the in-memory series for at least 1 tenant.
+This alert fires when a Cortex ingester is failing to compact the TSDB head into a block.
+
+A TSDB instance is opened for each tenant writing at least 1 series to the ingester and its head contains the in-memory series not flushed to a block yet. Once the TSDB head is compactable, the ingester will try to compact it every 1 minute. If the TSDB head compaction repeatedly fails, it means it's failing to compact a block from the in-memory series for at least 1 tenant, and it's a critical condition that should be immediately investigated.
 
 How to investigate:
 - Look for details in the ingester logs


### PR DESCRIPTION
In this PR I've improved the blocks storage ingester alerts:

- Do not fire `CortexIngesterHasNotShippedBlocks` or `CortexIngesterHasNotShippedBlocksSinceStart` if the ingester is not receiving any write traffic
- Added `CortexIngesterTSDBHeadCompactionFailed` to alert if TSDB head compaction is failing on a ingester (compaction is retried every minute)