### PR TITLE
Add alert and dashboard for config file hashes

### DIFF
--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -92,6 +92,21 @@
           },
         },
         {
+          alert: 'CortexInconsistentConfig',
+          expr: |||
+            count(count by(%s, job, sha256) (cortex_config_hash)) without(sha256) > 1
+          ||| % $._config.alert_aggregation_labels,
+          'for': '1h',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              An inconsistent config file hash is used across cluster {{ $labels.job }}.
+            |||,
+          },
+        },
+        {
           // As of https://github.com/cortexproject/cortex/pull/2092, this metric is
           // only exposed when it is supposed to be non-zero, so we don't need to do
           // any special filtering on the job label.

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -1,5 +1,6 @@
 {
   grafanaDashboards+:
+    (import 'dashboards/config.libsonnet') +
     (import 'dashboards/queries.libsonnet') +
     (import 'dashboards/reads.libsonnet') +
     (import 'dashboards/ruler.libsonnet') +

--- a/cortex-mixin/dashboards/config.libsonnet
+++ b/cortex-mixin/dashboards/config.libsonnet
@@ -1,0 +1,26 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+
+  'cortex-config.json':
+    $.dashboard('Cortex / Config')
+    .addClusterSelectorTemplates()
+    .addRow(
+      $.row('Startup config file')
+      .addPanel(
+        $.panel('Startup config file hashes') +
+        $.queryPanel('count(cortex_config_hash{%s}) by (sha256)' % $.namespaceMatcher(), 'sha256:{{sha256}}') +
+        $.stack +
+        { yaxes: $.yaxes('instances') },
+      )
+    )
+    .addRow(
+      $.row('Runtime config file')
+      .addPanel(
+        $.panel('Runtime config file hashes') +
+        $.queryPanel('count(cortex_runtime_config_hash{%s}) by (sha256)' % $.namespaceMatcher(), 'sha256:{{sha256}}') +
+        $.stack +
+        { yaxes: $.yaxes('instances') },
+      )
+    ),
+}


### PR DESCRIPTION
This allows to monitor the roll-out of new config file version to the various members of a cluster.

The metric itself was added as part of https://github.com/cortexproject/cortex/pull/2874.

Ideally someone double checks the filters I am using. I am also not 100% sure if really all nodes of a cluster typically have the exact same config and if the period of 1hours is reasonable.

This doesn't alert on runtime config divergence

![scrn-2020-07-21-17-11-55](https://user-images.githubusercontent.com/223048/88081135-e282ef80-cb77-11ea-9e19-be952ab6f377.png)
![scrn-2020-07-21-17-11-45](https://user-images.githubusercontent.com/223048/88081138-e31b8600-cb77-11ea-88bc-d1aa44958495.png)
