### PR TITLE
Support Alertmanager HA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## master / unreleased
 
+* [BUGFIX] Add support the `local` ruler client type
 * [CHANGE] The project is now licensed with Apache-2.0 license. #169
 * [CHANGE] Add overrides config to tsdb store-gateway. #167
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
-* [BUGFIX] Add support the `local` ruler client type
+* [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 
 ## 1.3.0 / 2020-08-21
 

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -7,7 +7,7 @@
   local isGossiping = $._config.alertmanager.replicas > 1,
   local peers = if isGossiping then
     [
-      'alertmanager-%d.alertmanager.%s.svc.%s.local:%s' % [i, $._config.namespace, $._config.cluster, $._config.alertmanager_gossip_port]
+      'alertmanager-%d.alertmanager.%s.svc.%s.local:%s' % [i, $._config.namespace, $._config.cluster, $._config.alertmanager.gossip_port]
       for i in std.range(0, $._config.alertmanager.replicas - 1)
     ]
   else [],
@@ -38,8 +38,8 @@
       container.withPorts(
         $.util.defaultPorts +
         if isGossiping then [
-          $.core.v1.containerPort.newUDP('gossip-udp', $._config.alertmanager_gossip_port),
-          $.core.v1.containerPort.new('gossip-tcp', $._config.alertmanager_gossip_port),
+          $.core.v1.containerPort.newUDP('gossip-udp', $._config.alertmanager.gossip_port),
+          $.core.v1.containerPort.new('gossip-tcp', $._config.alertmanager.gossip_port),
         ]
         else [],
       ) +

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -243,6 +243,10 @@
         },
       }[$._config.ruler_client_type],
 
+    alertmanager: {
+      replicas: 1,
+    },
+
     overrides: {
       // === Per-tenant usage limits. ===
       //

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -244,7 +244,7 @@
       }[$._config.ruler_client_type],
 
     alertmanager: {
-      replicas: 1,
+      replicas: 3,
       gossip_port: 9094,
     },
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -245,6 +245,7 @@
 
     alertmanager: {
       replicas: 1,
+      gossip_port: 9094,
     },
 
     overrides: {

--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -18,8 +18,7 @@
     store_gateway: self.cortex,
 
     query_tee: 'quay.io/cortexproject/query-tee:master-5d7b05c3',
-    // TODO(gouthamve/jtlisi): Upstream the ruler and AM configs.
-    alertmanager: 'jtlisi/cortex:20190819_alertmanager_update-faa66aa43',
+    alertmanager: 'quay.io/cortexproject/cortex:master-2b41aa38d',
     testExporter: 'cortexproject/test-exporter:master-be013707',
   },
 }

--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -5,8 +5,9 @@
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.
-    cortex: 'cortexproject/cortex:v1.2.0',
+    cortex: 'cortexproject/cortex:v1.3.0',
 
+    alertmanager: self.cortex,
     distributor: self.cortex,
     ingester: self.cortex,
     querier: self.cortex,
@@ -18,7 +19,6 @@
     store_gateway: self.cortex,
 
     query_tee: 'quay.io/cortexproject/query-tee:master-5d7b05c3',
-    alertmanager: 'quay.io/cortexproject/cortex:master-2b41aa38d',
     testExporter: 'cortexproject/test-exporter:master-be013707',
   },
 }


### PR DESCRIPTION
With this, we can now support increasing the number of replicas for a
Cortex AM thus enabling HA.

 Please note that Alerts themselves are not gossiped between
Alertmanagers. Each Ruler needs to send the alert to every Alertmanager
available thus the reason why a headless service gets created when the
number of replicas is more than 1.