### PR TITLE
Chunks blocks migration

### DIFF
--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -75,10 +75,12 @@
 
   local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
 
-  ingester_pdb:
+  newIngesterPdb(name, matchingNameLabel)::
     podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName('ingester-pdb') +
-    podDisruptionBudget.mixin.metadata.withLabels({ name: 'ingester-pdb' }) +
-    podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: name }) +
+    podDisruptionBudget.mixin.metadata.withName(name) +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: name }) +
+    podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: matchingNameLabel }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
+
+  ingester_pdb: self.newIngesterPdb('ingester-pdb', name),
 }

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -75,11 +75,11 @@
 
   local podDisruptionBudget = $.policy.v1beta1.podDisruptionBudget,
 
-  newIngesterPdb(name, matchingNameLabel)::
+  newIngesterPdb(pdbName, ingesterName)::
     podDisruptionBudget.new() +
-    podDisruptionBudget.mixin.metadata.withName(name) +
-    podDisruptionBudget.mixin.metadata.withLabels({ name: name }) +
-    podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: matchingNameLabel }) +
+    podDisruptionBudget.mixin.metadata.withName(pdbName) +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: pdbName }) +
+    podDisruptionBudget.mixin.spec.selector.withMatchLabels({ name: ingesterName }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
 
   ingester_pdb: self.newIngesterPdb('ingester-pdb', name),

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -10,7 +10,7 @@
     {
       target: 'querier',
 
-      // Increase HTTP server response write timeout, as we were seeing some
+      // Increase HTTP server response write timeout, as we were seeing some
       // queries that return a lot of data timeing out.
       'server.http-write-timeout': '1m',
 
@@ -21,6 +21,8 @@
       'querier.worker-parallelism': $._config.querier.concurrency / $._config.queryFrontend.replicas,
       'querier.frontend-address': 'query-frontend-discovery.%(namespace)s.svc.cluster.local:9095' % $._config,
       'querier.frontend-client.grpc-max-send-msg-size': 100 << 20,
+
+      'querier.second-store-engine': $._config.querier_second_storage_engine,
 
       'log.level': 'debug',
     },

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -84,24 +84,25 @@
     'ingester.tokens-file-path': '/data/tokens',
   },
 
-  ingester_container+::
-    container.withVolumeMountsMixin([
-      volumeMount.new('ingester-data', '/data'),
-    ]),
-
-  ingester_statefulset:
-    statefulSet.new('ingester', 3, [$.ingester_container], ingester_data_pvc) +
-    statefulSet.mixin.spec.withServiceName('ingester') +
+  newIngesterStatefulSet(name, container)::
+    statefulSet.new(name, 3, [
+      container + $.core.v1.container.withVolumeMountsMixin([
+        volumeMount.new('ingester-data', '/data'),
+      ]),
+    ], ingester_data_pvc) +
+    statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
-    statefulSet.mixin.metadata.withLabels({ name: 'ingester' }) +
-    statefulSet.mixin.spec.template.metadata.withLabels({ name: 'ingester' } + $.ingester_deployment_labels) +
-    statefulSet.mixin.spec.selector.withMatchLabels({ name: 'ingester' }) +
+    statefulSet.mixin.metadata.withLabels({ name: name }) +
+    statefulSet.mixin.spec.template.metadata.withLabels({ name: name } + $.ingester_deployment_labels) +
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: name }) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.util.podPriority('high') +
     $.util.antiAffinity,
+
+  ingester_statefulset: self.newIngesterStatefulSet('ingester', $.ingester_container),
 
   ingester_service:
     $.util.serviceFor($.ingester_statefulset, $.ingester_service_ignored_labels),


### PR DESCRIPTION
This PR adds some support for making chunks <-> blocks migration easier:

- adds ability to configure secondary store for querying
- modifies generation of blocks ingester's statefulset so that it's possible to instantiate it with different name.
