### PR TITLE
Bump gRPC max tx/rx to 100MB for ingester and distributor

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -224,7 +224,7 @@
           'ruler.storage.gcs.bucketname': $._config.ruler_gcs_bucket_name,
         },
         s3: {
-          's3.url': 'https://%s/%s' % [$._config.aws_region, $._config.s3_bucket_name],
+          's3.url': 'https://%s/%s' % [$._config.aws_region, $._config.ruler_s3_bucket_name],
         },
       }[$._config.ruler_client_type],
 

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -28,6 +28,10 @@
       'server.grpc.keepalive.max-connection-age-grace': '5m',
       'server.grpc.keepalive.max-connection-idle': '1m',
 
+      // 100MB (bumped from default of 4MB)
+      'server.grpc-max-recv-msg-size-bytes': 1024 * 1024 * 100,
+      'server.grpc-max-send-msg-size-bytes': 1024 * 1024 * 100,
+
       'distributor.ingestion-rate-limit-strategy': 'global',
       'distributor.ingestion-rate-limit': 100000,  // 100K
       'distributor.ingestion-burst-size': 1000000,  // 1M

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -29,6 +29,10 @@
       'ingester.max-series-per-metric': 0,  // Disabled in favour of the max global limit
       'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
       'server.grpc-max-concurrent-streams': 100000,
+
+      // 100MB (bumped from default of 4MB)
+      'server.grpc-max-recv-msg-size-bytes': 1024 * 1024 * 100,
+      'server.grpc-max-send-msg-size-bytes': 1024 * 1024 * 100,
     } + (
       if $._config.memcached_index_writes_enabled then
         {

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -28,8 +28,9 @@
     // connections.
     'querier.compress-http-responses': true,
 
-    // So it can recieve big responses from the querier.
-    'server.grpc-max-recv-msg-size-bytes': 100 << 20,
+    // 100MB (bumped from default of 4MB)
+    'server.grpc-max-recv-msg-size-bytes': 1024 * 1024 * 100,
+    'server.grpc-max-send-msg-size-bytes': 1024 * 1024 * 100,
 
     // Limit queries to 500 days, allow this to be override per-user.
     'store.max-query-length': '12000h',  // 500 Days


### PR DESCRIPTION
This just changes the send and receive limits to match what was configured in the `query-frontend` (and changes the definition of 100MB from `100 << 20` to `1024 * 1024 * 100`. My logs are full of `ResourceExhausted desc = trying to send message larger than max`, and I'm guessing it's just an oversight that the ingester and distributor didn't get their default limits bumped to match.