### PR TITLE
Cleanup blocks storage config

### DIFF
--- a/cortex-mixin/alerts.libsonnet
+++ b/cortex-mixin/alerts.libsonnet
@@ -2,7 +2,7 @@
   prometheusAlerts+::
     (import 'alerts/alerts.libsonnet') +
 
-    (if std.setMember('tsdb', $._config.storage_engine)
+    (if std.setMember('blocks', $._config.storage_engine)
      then
        (import 'alerts/blocks.libsonnet') +
        (import 'alerts/compactor.libsonnet')

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -4,9 +4,9 @@
 
   _config+:: {
     // Switch for overall storage engine.
-    // May contain 'chunks', 'tsdb' or both.
-    // Enables chunks- or tsdb- specific panels and dashboards.
-    storage_engine: ['chunks', 'tsdb'],
+    // May contain 'chunks', 'blocks' or both.
+    // Enables chunks- or blocks- specific panels and dashboards.
+    storage_engine: ['chunks', 'blocks'],
 
     // For chunks backend, switch for chunk index type.
     // May contain 'bigtable', 'dynamodb' or 'cassandra'.

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -7,7 +7,7 @@
     (import 'dashboards/scaling.libsonnet') +
     (import 'dashboards/writes.libsonnet') +
 
-    (if std.setMember('tsdb', $._config.storage_engine)
+    (if std.setMember('blocks', $._config.storage_engine)
      then
        (import 'dashboards/compactor.libsonnet') +
        (import 'dashboards/compactor-resources.libsonnet') +
@@ -18,7 +18,7 @@
      then import 'dashboards/chunks.libsonnet'
      else {}) +
 
-    (if std.setMember('tsdb', $._config.storage_engine)
+    (if std.setMember('blocks', $._config.storage_engine)
         && std.setMember('chunks', $._config.storage_engine)
      then import 'dashboards/comparison.libsonnet'
      else {}) +

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -144,7 +144,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Store-gateway - Blocks')
       .addPanel(
         $.panel('Blocks queried / sec') +
@@ -165,7 +165,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('')
       .addPanel(
         $.panel('Series fetch duration (per request)') +
@@ -181,7 +181,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('')
       .addPanel(
         $.panel('Blocks currently loaded') +

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -53,7 +53,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Store-gateway')
       .addPanel(
         $.containerCPUUsagePanel('CPU', 'store-gateway'),

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -60,7 +60,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Store-gateway')
       .addPanel(
         $.panel('QPS') +
@@ -96,7 +96,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Memcached – Blocks Storage – Index header (Store-gateway)')
       .addPanel(
         $.panel('QPS') +
@@ -115,15 +115,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.thanosMemcachedCache('Memcached – Blocks Storage – Chunks (Store-gateway)', $._config.job_names.store_gateway, 'store-gateway', 'chunks-cache')
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.thanosMemcachedCache('Memcached – Blocks Storage – Metadada (Store-gateway)', $._config.job_names.store_gateway, 'store-gateway', 'metadata-cache')
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.thanosMemcachedCache('Memcached – Blocks Storage – Metadada (Querier)', $._config.job_names.querier, 'querier', 'metadata-cache')
     )
     .addRowIf(
@@ -180,20 +180,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     // Object store metrics for the store-gateway.
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.objectStorePanels1('Store-gateway - Blocks Object Store', 'store-gateway'),
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.objectStorePanels2('', 'store-gateway'),
     )
     // Object store metrics for the querier.
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.objectStorePanels1('Querier - Blocks Object Store', 'querier'),
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.objectStorePanels2('', 'querier'),
     ),
 }

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -150,7 +150,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Ingester - Blocks storage - Shipper')
       .addPanel(
         $.successFailurePanel(
@@ -165,7 +165,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Ingester - Blocks storage - TSDB Head')
       .addPanel(
         $.successFailurePanel(
@@ -180,7 +180,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('tsdb', $._config.storage_engine),
+      std.setMember('blocks', $._config.storage_engine),
       $.row('Ingester - Blocks storage - TSDB WAL')
       .addPanel(
         $.successFailurePanel(

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -59,7 +59,7 @@
     storage_engine: 'chunks',
     // Secondary storage engine is only used for querying.
     querier_second_storage_engine: null,
-    storage_tsdb_bucket_name: error 'must specify GCS bucket name to store TSDB blocks',
+    blocks_storage_bucket_name: error 'must specify GCS bucket name to store TSDB blocks',
 
     store_gateway_replication_factor: 3,
 
@@ -140,7 +140,7 @@
         'experimental.blocks-storage.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
         'experimental.blocks-storage.tsdb.ship-interval': '1m',
         'experimental.blocks-storage.backend': 'gcs',
-        'experimental.blocks-storage.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
+        'experimental.blocks-storage.gcs.bucket-name': $._config.blocks_storage_bucket_name,
         'experimental.store-gateway.sharding-enabled': true,
         'experimental.store-gateway.sharding-ring.store': 'consul',
         'experimental.store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -126,12 +126,11 @@
       $._config.client_configs.aws +
       $._config.client_configs.cassandra +
       $._config.client_configs.gcp +
-      $._config.storageTSDBConfig +
       { 'schema-config-file': '/etc/cortex/schema/config.yaml' },
 
     // Blocks storage configuration, used only when 'blocks' storage
     // engine is explicitly enabled.
-    storageTSDBConfig: (
+    blocksStorageConfig: (
       if $._config.storage_engine == 'blocks' || $._config.querier_second_storage_engine == 'blocks' then {
         'store.engine': $._config.storage_engine,  // May still be chunks
         'experimental.blocks-storage.tsdb.dir': '/data/tsdb',

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -5,6 +5,7 @@
     $._config.ringConfig +
     $._config.storeConfig +
     $._config.storageConfig +
+    $._config.blocksStorageConfig +
     $._config.distributorConfig +  // This adds the distributor ring flags to the ingester.
     {
       target: 'ingester',

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -5,6 +5,7 @@
     $._config.ringConfig +
     $._config.storeConfig +
     $._config.storageConfig +
+    $._config.blocksStorageConfig +
     $._config.queryConfig +
     $._config.distributorConfig +
     {

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -5,6 +5,7 @@
     $._config.ringConfig +
     $._config.storeConfig +
     $._config.storageConfig +
+    $._config.blocksStorageConfig +
     $._config.queryConfig +
     $._config.distributorConfig +
     $._config.rulerClientConfig +

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -124,7 +124,8 @@
     pvc.mixin.metadata.withName('compactor-data'),
 
   compactor_args::
-    $._config.storageConfig
+    $._config.storageConfig +
+    $._config.blocksStorageConfig +
     {
       target: 'compactor',
 
@@ -167,7 +168,8 @@
     pvc.mixin.metadata.withName('store-gateway-data'),
 
   store_gateway_args::
-    $._config.storageConfig
+    $._config.storageConfig +
+    $._config.blocksStorageConfig +
     {
       target: 'store-gateway',
 


### PR DESCRIPTION
A final round of cleanup for the blocks storage config.

**Changes**:
- Blocks storage config is no more applied to query-frontend, table-manager and purger
- `storage_engine` value changed from `tsdb` to `blocks` in `cortex-mixin` (dashboards and alerts)
- `storage_tsdb_bucket_name` renamed to `blocks_storage_bucket_name`

**Internal config renaming** (in case you're overriding it):
- `storageTSDBConfig` renamed to `blocksStorageConfig`
