### PR TITLE
Fixed std.setMember() usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,14 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:e6474c5
+      - image: grafana/cortex-jsonnet-build-image:387f7ca
     steps:
       - checkout
       - run: make lint
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:e6474c5
+      - image: grafana/cortex-jsonnet-build-image:387f7ca
     steps:
       - checkout
       - run: make build-mixin

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.11 AS jsonnet-builder
 RUN apk add --no-cache git make g++
 RUN git clone https://github.com/google/jsonnet && \
-    git  -C jsonnet checkout v0.14.0 && \
+    git  -C jsonnet checkout v0.15.0 && \
     make -C jsonnet 2LDFLAGS=-static && \
     cp jsonnet/jsonnet /usr/bin && \
     cp jsonnet/jsonnetfmt /usr/bin

--- a/cortex-mixin/alerts.libsonnet
+++ b/cortex-mixin/alerts.libsonnet
@@ -2,7 +2,7 @@
   prometheusAlerts+::
     (import 'alerts/alerts.libsonnet') +
 
-    (if std.setMember('blocks', $._config.storage_engine)
+    (if std.member($._config.storage_engine, 'blocks')
      then
        (import 'alerts/blocks.libsonnet') +
        (import 'alerts/compactor.libsonnet')

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -7,19 +7,19 @@
     (import 'dashboards/scaling.libsonnet') +
     (import 'dashboards/writes.libsonnet') +
 
-    (if std.setMember('blocks', $._config.storage_engine)
+    (if std.member($._config.storage_engine, 'blocks')
      then
        (import 'dashboards/compactor.libsonnet') +
        (import 'dashboards/compactor-resources.libsonnet') +
        (import 'dashboards/object-store.libsonnet')
      else {}) +
 
-    (if std.setMember('chunks', $._config.storage_engine)
+    (if std.member($._config.storage_engine, 'chunks')
      then import 'dashboards/chunks.libsonnet'
      else {}) +
 
-    (if std.setMember('blocks', $._config.storage_engine)
-        && std.setMember('chunks', $._config.storage_engine)
+    (if std.member($._config.storage_engine, 'blocks')
+        && std.member($._config.storage_engine, 'chunks')
      then import 'dashboards/comparison.libsonnet'
      else {}) +
 

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -66,7 +66,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'chunks'),
       $.row('Querier - Chunks storage - Index Cache')
       .addPanel(
         $.panel('Total entries') +
@@ -101,7 +101,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'chunks'),
       $.row('Querier - Chunks storage - Store')
       .addPanel(
         $.panel('Index Lookups per Query') +
@@ -125,7 +125,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'chunks'),
       $.row('Querier - Blocks storage')
       .addPanel(
         $.panel('Number of store-gateways hit per Query') +
@@ -144,7 +144,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway - Blocks')
       .addPanel(
         $.panel('Blocks queried / sec') +
@@ -165,7 +165,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('')
       .addPanel(
         $.panel('Series fetch duration (per request)') +
@@ -181,7 +181,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('')
       .addPanel(
         $.panel('Blocks currently loaded') +

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -53,7 +53,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway')
       .addPanel(
         $.containerCPUUsagePanel('CPU', 'store-gateway'),

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -60,7 +60,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway')
       .addPanel(
         $.panel('QPS') +
@@ -72,7 +72,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Index')
       .addPanel(
         $.panel('QPS') +
@@ -84,7 +84,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Chunks')
       .addPanel(
         $.panel('QPS') +
@@ -96,7 +96,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Memcached – Blocks Storage – Index header (Store-gateway)')
       .addPanel(
         $.panel('QPS') +
@@ -115,20 +115,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.thanosMemcachedCache('Memcached – Blocks Storage – Chunks (Store-gateway)', $._config.job_names.store_gateway, 'store-gateway', 'chunks-cache')
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.thanosMemcachedCache('Memcached – Blocks Storage – Metadada (Store-gateway)', $._config.job_names.store_gateway, 'store-gateway', 'metadata-cache')
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.thanosMemcachedCache('Memcached – Blocks Storage – Metadada (Querier)', $._config.job_names.querier, 'querier', 'metadata-cache')
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('cassandra', $._config.chunk_index_backend + $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
         $.panel('QPS') +
@@ -140,8 +140,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('bigtable', $._config.chunk_index_backend + $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
         $.panel('QPS') +
@@ -153,8 +153,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ),
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('dynamodb', $._config.chunk_index_backend + $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
         $.panel('QPS') +
@@ -166,8 +166,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ),
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('gcs', $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
         $.panel('QPS') +
@@ -180,20 +180,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     // Object store metrics for the store-gateway.
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.objectStorePanels1('Store-gateway - Blocks Object Store', 'store-gateway'),
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.objectStorePanels2('', 'store-gateway'),
     )
     // Object store metrics for the querier.
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.objectStorePanels1('Querier - Blocks Object Store', 'querier'),
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.objectStorePanels2('', 'querier'),
     ),
 }

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached')
       .addPanel(
         $.panel('QPS') +
@@ -98,8 +98,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('cassandra', $._config.chunk_index_backend + $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
         $.panel('QPS') +
@@ -111,8 +111,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('bigtable', $._config.chunk_index_backend + $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
         $.panel('QPS') +
@@ -124,8 +124,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('dynamodb', $._config.chunk_index_backend + $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
         $.panel('QPS') +
@@ -137,8 +137,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('chunks', $._config.storage_engine) &&
-      std.setMember('gcs', $._config.chunk_store_backend),
+      std.member($._config.storage_engine, 'chunks') &&
+      std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
         $.panel('QPS') +
@@ -150,7 +150,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Ingester - Blocks storage - Shipper')
       .addPanel(
         $.successFailurePanel(
@@ -165,7 +165,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Ingester - Blocks storage - TSDB Head')
       .addPanel(
         $.successFailurePanel(
@@ -180,7 +180,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRowIf(
-      std.setMember('blocks', $._config.storage_engine),
+      std.member($._config.storage_engine, 'blocks'),
       $.row('Ingester - Blocks storage - TSDB WAL')
       .addPanel(
         $.successFailurePanel(


### PR DESCRIPTION
Today I learned the hard way that `std.setMember()` requires the array to be sorted, while `std.member()` doesn't. So far it worked by coincidence, because we were defining `storage_engine: ['chunks', 'tsdb']` but after renaming `tsdb` to `blocks` it stopped working as expected. I replaced the usage of `std.setMember()` with `std.member()`.

To use the new function, I've upgraded the jsonnet requirement from `0.14.0` to `0.15.0`.