### PR TITLE
Add playbook entry for sample with repeated timestamp

### DIFF
--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -1,6 +1,6 @@
 # Playbooks
 
-This document contains playbooks, or at least a checklist of what to look for, for alerts in the cortex-mixin. This document assumes that you are running a Cortex cluster:
+This document contains playbooks, or at least a checklist of what to look for, for alerts in the cortex-mixin and logs from Cortex. This document assumes that you are running a Cortex cluster:
 
 1. Using this mixin config
 2. Using GCS as object store (but similar procedures apply to other backends)
@@ -362,3 +362,16 @@ A PVC can be manually deleted by an operator. When a PVC claim is deleted, what 
 
 - `Retain`: the volume will not be deleted until the PV resource will be manually deleted from Kubernetes
 - `Delete`: the volume will be automatically deleted
+
+
+## Log lines
+
+### Log line containing 'sample with repeated timestamp but different value'
+
+This means a sample with the same timestamp as an existing one was received with a different value. The number of occurrences is recorded in the `prometheus_target_scrapes_sample_out_of_order_total` metric.
+
+Possible reasons for this are:
+- Multiple agents are scraping the same app without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the deplicate sample. Change the labels of each sample generated per agent so they are unique.
+- Incorrect relabelling rules can cause a label to be dropped from a sample so that multiple samples have the same labels. If these samples were collected at the same time they will cause this error.
+- The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.
+- Prometheus scrapes at the millisecond level. If the scrapes are done very quickly the same sample could be returned. This is very unlikely.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -368,7 +368,7 @@ A PVC can be manually deleted by an operator. When a PVC claim is deleted, what 
 
 ### Log line containing 'sample with repeated timestamp but different value'
 
-This means a sample with the same timestamp as an existing one was received with a different value. The number of occurrences is recorded in the `prometheus_target_scrapes_sample_out_of_order_total` metric.
+This means a sample with the same timestamp as the latest one was received with a different value. The number of occurrences is recorded in the `cortex_discarded_samples_total` metric with the label `reason="new-value-for-timestamp"`.
 
 Possible reasons for this are:
 - Multiple agents are scraping the same app without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -371,6 +371,5 @@ A PVC can be manually deleted by an operator. When a PVC claim is deleted, what 
 This means a sample with the same timestamp as the latest one was received with a different value. The number of occurrences is recorded in the `cortex_discarded_samples_total` metric with the label `reason="new-value-for-timestamp"`.
 
 Possible reasons for this are:
-- Multiple Prometheus servers / Grafana agents are scraping the same target without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.
 - Incorrect relabelling rules can cause a label to be dropped from a series so that multiple series have the same labels. If these series were collected from the same target they will have the same timestamp.
 - The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -372,6 +372,5 @@ This means a sample with the same timestamp as the latest one was received with 
 
 Possible reasons for this are:
 - Multiple Prometheus servers / Grafana agents are scraping the same target without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.
-- Incorrect relabelling rules can cause a label to be dropped from a sample so that multiple samples have the same labels. If these samples were collected at the same time they will cause this error.
+- Incorrect relabelling rules can cause a label to be dropped from a sample so that multiple samples have the same labels. If these samples were collected from the same target they will have the same timestamp. An example is dropping the `cpu` label when there are multiple cpus.
 - The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.
-- Prometheus scrapes at the millisecond level. If the scrapes are done very quickly the same sample could be returned. This is very unlikely.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -371,7 +371,7 @@ A PVC can be manually deleted by an operator. When a PVC claim is deleted, what 
 This means a sample with the same timestamp as the latest one was received with a different value. The number of occurrences is recorded in the `cortex_discarded_samples_total` metric with the label `reason="new-value-for-timestamp"`.
 
 Possible reasons for this are:
-- Multiple agents are scraping the same app without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.
+- Multiple Prometheus servers / Grafana agents are scraping the same target without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.
 - Incorrect relabelling rules can cause a label to be dropped from a sample so that multiple samples have the same labels. If these samples were collected at the same time they will cause this error.
 - The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.
 - Prometheus scrapes at the millisecond level. If the scrapes are done very quickly the same sample could be returned. This is very unlikely.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -372,5 +372,5 @@ This means a sample with the same timestamp as the latest one was received with 
 
 Possible reasons for this are:
 - Multiple Prometheus servers / Grafana agents are scraping the same target without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.
-- Incorrect relabelling rules can cause a label to be dropped from a sample so that multiple samples have the same labels. If these samples were collected from the same target they will have the same timestamp. An example is dropping the `cpu` label when there are multiple cpus.
+- Incorrect relabelling rules can cause a label to be dropped from a series so that multiple series have the same labels. If these series were collected from the same target they will have the same timestamp.
 - The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -371,7 +371,7 @@ A PVC can be manually deleted by an operator. When a PVC claim is deleted, what 
 This means a sample with the same timestamp as an existing one was received with a different value. The number of occurrences is recorded in the `prometheus_target_scrapes_sample_out_of_order_total` metric.
 
 Possible reasons for this are:
-- Multiple agents are scraping the same app without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the deplicate sample. Change the labels of each sample generated per agent so they are unique.
+- Multiple agents are scraping the same app without deduplication in place. Check the IP addresses mentioned in the log line for the agent that returned the duplicate sample. Change the labels of each sample generated per agent so they are unique.
 - Incorrect relabelling rules can cause a label to be dropped from a sample so that multiple samples have the same labels. If these samples were collected at the same time they will cause this error.
 - The exporter being scraped sets the same timestamp on every scrape. Note that exporters should generally not set timestamps.
 - Prometheus scrapes at the millisecond level. If the scrapes are done very quickly the same sample could be returned. This is very unlikely.


### PR DESCRIPTION
This was added as a result of https://github.com/cortexproject/cortex/pull/2985. This documents reasons why the 'sample with repeated timestamp but different value' error appears in the log.