### PR TITLE
Per Instance Read/Write Panels

### DIFF
--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -42,5 +42,8 @@
 
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
     resources_dashboards_enabled: false,
+
+    // If supplied adds additional panels that are broken down per instance.  i.e. 'pod' in a kubernetes install
+    per_instance_label: '',
   },
 }

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -44,6 +44,6 @@
     resources_dashboards_enabled: false,
 
     // If supplied adds additional panels that are broken down per instance.  i.e. 'pod' in a kubernetes install
-    per_instance_label: 'pod',
+    per_instance_label: '',
   },
 }

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -43,7 +43,7 @@
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
     resources_dashboards_enabled: false,
 
-    // If supplied adds additional panels that are broken down per instance.  i.e. 'pod' in a kubernetes install
-    per_instance_label: '',
+    // Used on panels that show metrics per instance.  i.e. 'pod' in a kubernetes install
+    per_instance_label: 'pod',
   },
 }

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -44,6 +44,6 @@
     resources_dashboards_enabled: false,
 
     // If supplied adds additional panels that are broken down per instance.  i.e. 'pod' in a kubernetes install
-    per_instance_label: '',
+    per_instance_label: 'pod',
   },
 }

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -78,10 +78,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
     },
 
-  // hiddenLegendQueryPanel is a standard query panel designed to handle a large number of series.  it hides the legend, doesn't fill the series and 
+  // hiddenLegendQueryPanel is a standard query panel designed to handle a large number of series.  it hides the legend, doesn't fill the series and
   //  sorts the tooltip descending
   hiddenLegendQueryPanel(queries, legends, legendLink=null)::
-    $.queryPanel(queries, legends, legendLink) + 
+    $.queryPanel(queries, legends, legendLink) +
     {
       legend: { show: false },
       fill: 0,

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -38,12 +38,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
              .addMultiTemplate('namespace', 'cortex_build_info', 'namespace'),
     },
 
-  // The ,ixin allow specialism of the job selector depending on if its a single binary
+  row(title)::
+    super.row(title) + {
+      addPanelIf(condition, panel)::
+        if condition
+        then self.addPanel(panel)
+        else self,
+    },
+
+  // The mixin allow specialism of the job selector depending on if its a single binary
   // deployment or a namespaced one.
   jobMatcher(job)::
     if $._config.singleBinary
     then 'job=~"$job"'
     else 'cluster=~"$cluster", job=~"($namespace)/%s"' % job,
+
+  jobMatcherEquality(job)::
+    if $._config.singleBinary
+    then 'job=~"$job"'
+    else 'cluster="$cluster", namespace="$namespace", job=~"($namespace)/%s"' % job,
 
   namespaceMatcher()::
     if $._config.singleBinary

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -78,6 +78,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
     },
 
+  // hiddenLegendQueryPanel is a standard query panel designed to handle a large number of series.  it hides the legend, doesn't fill the series and 
+  //  sorts the tooltip descending
+  hiddenLegendQueryPanel(queries, legends, legendLink=null)::
+    $.queryPanel(queries, legends, legendLink) + 
+    {
+      legend: { show: false },
+      fill: 0,
+      tooltip: { sort: 2 },
+    },
+
   qpsPanel(selector)::
     super.qpsPanel(selector) + {
       targets: [

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -38,14 +38,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
              .addMultiTemplate('namespace', 'cortex_build_info', 'namespace'),
     },
 
-  row(title)::
-    super.row(title) + {
-      addPanelIf(condition, panel)::
-        if condition
-        then self.addPanel(panel)
-        else self,
-    },
-
   // The mixin allow specialism of the job selector depending on if its a single binary
   // deployment or a namespaced one.
   jobMatcher(job)::
@@ -53,6 +45,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     then 'job=~"$job"'
     else 'cluster=~"$cluster", job=~"($namespace)/%s"' % job,
 
+  // jobMatcherEquality performs exact matches on cluster and namespace.  Should be used on
+  //  panels that are expected to return too many series to be useful when multiplier
+  //  namespaces or clusters are selected.
   jobMatcherEquality(job)::
     if $._config.singleBinary
     then 'job=~"$job"'

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -14,6 +14,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', 'api_prom_api_v1_.+')])
       )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_prom_api_v1_.+"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.gateway)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
+      )
     )
     .addRow(
       $.row('Query Frontend')
@@ -24,6 +32,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', 'api_prom_api_v1_.+')])
+      )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_prom_api_v1_.+"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.query_frontend)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
       )
     )
     .addRow(
@@ -47,6 +63,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.querier) + [utils.selector.re('route', 'api_prom_api_v1_.+')])
       )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_prom_api_v1_.+"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.querier)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
+      )
     )
     .addRow(
       $.row('Ingester')
@@ -57,6 +81,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.re('route', '/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata')])
+      )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.ingester)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
       )
     )
     .addRowIf(
@@ -69,6 +101,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.store_gateway) + [utils.selector.re('route', '/gatewaypb.StoreGateway/.*')])
+      )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/gatewaypb.StoreGateway/.*"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.store_gateway)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
       )
     )
     .addRowIf(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -14,8 +14,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', 'api_prom_api_v1_.+')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_prom_api_v1_.+"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.gateway)], ''
@@ -33,8 +32,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', 'api_prom_api_v1_.+')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_prom_api_v1_.+"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.query_frontend)], ''
@@ -63,8 +61,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.querier) + [utils.selector.re('route', 'api_prom_api_v1_.+')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_prom_api_v1_.+"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.querier)], ''
@@ -82,8 +79,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.re('route', '/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.ingester)], ''
@@ -102,8 +98,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.store_gateway) + [utils.selector.re('route', '/gatewaypb.StoreGateway/.*')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/gatewaypb.StoreGateway/.*"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.store_gateway)], ''

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -40,8 +40,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.eq('route', 'api_prom_push')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="api_prom_push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.gateway)], ''
@@ -59,8 +58,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.distributor) + [utils.selector.re('route', '/httpgrpc.*|api_prom_push')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/httpgrpc.*|api_prom_push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.distributor)], ''
@@ -89,8 +87,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.eq('route', '/cortex.Ingester/Push')])
       )
-      .addPanelIf(
-        $._config.per_instance_label != '',
+      .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="/cortex.Ingester/Push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.ingester)], ''

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -59,6 +59,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.distributor) + [utils.selector.re('route', '/httpgrpc.*|api_prom_push')])
       )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/httpgrpc.*|api_prom_push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.distributor)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
+      )
     )
     .addRow(
       $.row('KV Store (HA Dedupe)')
@@ -80,6 +88,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.eq('route', '/cortex.Ingester/Push')])
+      )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="/cortex.Ingester/Push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.ingester)], ''
+        ) +
+        { yaxes: $.yaxes('s') }
       )
     )
     .addRow(

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -40,6 +40,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.eq('route', 'api_prom_push')])
       )
+      .addPanelIf(
+        $._config.per_instance_label != '',
+        $.panel('Per %s Latency' % $._config.per_instance_label) +
+        $.queryPanel(
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="api_prom_push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.gateway)], ''
+        ) +
+        { yaxes: $.yaxes('s'), legend: { show: false }, fill: 0, tooltip: { sort: 2 } }
+      )
     )
     .addRow(
       $.row('Distributor')

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -42,11 +42,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
       .addPanelIf(
         $._config.per_instance_label != '',
-        $.panel('Per %s Latency' % $._config.per_instance_label) +
-        $.queryPanel(
+        $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
+        $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="api_prom_push"}[$__interval])))' % [$._config.per_instance_label, $.jobMatcherEquality($._config.job_names.gateway)], ''
         ) +
-        { yaxes: $.yaxes('s'), legend: { show: false }, fill: 0, tooltip: { sort: 2 } }
+        { yaxes: $.yaxes('s') }
       )
     )
     .addRow(


### PR DESCRIPTION
This PR is designed to expose per instance metrics in the read/write dashboards to help diagnose issues quickly that turn out to be occurring due to the underlying infrastructure.  It is not uncommon during an incident to start writing queries that expose per pod metrics directly and to discover that the issues are due to 1 or very few pods.  These changes will allow operators to quickly identify an issue as being isolated to a small subset of pods and take appropriate measures.

- Adds panels to the read/write dashboards to see per instance metrics
  - requires a configuration option that defaults to empty
- Adds utility methods to accomplish the above
- Per pod metrics are purposefully only shown after a cluster and namespace have been picked.

![image](https://user-images.githubusercontent.com/2272392/89821351-7105e380-db1c-11ea-8b65-abef7f47f38f.png)

