### PR TITLE
Add README instructions to CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:387f7ca
+      - image: grafana/cortex-jsonnet-build-image:55f5699
     steps:
       - checkout
       - run: make lint
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:387f7ca
+      - image: grafana/cortex-jsonnet-build-image:55f5699
     steps:
       - checkout
       - run: make build-mixin
@@ -26,7 +26,7 @@ jobs:
           path: cortex-mixin.zip
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:387f7ca
+      - image: grafana/cortex-jsonnet-build-image:55f5699
     steps:
       - checkout
       - run: make test-readme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
     jobs:
     - lint
     - build
+    - test-readme
 
 jobs:
   lint:
@@ -23,3 +24,9 @@ jobs:
       - run: make build-mixin
       - store_artifacts:
           path: cortex-mixin.zip
+  test-readme:
+    docker:
+      - image: grafana/cortex-jsonnet-build-image:387f7ca
+    steps:
+      - checkout
+      - run: make test-readme

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cortex-mixin.zip
 cortex-mixin/out
 cortex-mixin/vendor
+/test-readme/

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@
 JSONNET_FMT := jsonnetfmt
 
 lint:
-	@RESULT=0; \
-	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do \
-		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -; \
-		RESULT=$$(($$RESULT + $$?)); \
-	done; \
+	@RESULT=0;
+	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do
+		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -;
+		RESULT=$$(($$RESULT + $$?));
+	done;
 	exit $$RESULT
 
 fmt:
-	@find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+	@find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print |
 		xargs -n 1 -- $(JSONNET_FMT) -i
 
 build-image:
@@ -21,10 +21,24 @@ publish-build-image:
 	docker push grafana/cortex-jsonnet-build-image:$(shell git rev-parse --short HEAD)
 
 build-mixin:
-	cd cortex-mixin && \
-	rm -rf out && mkdir out && \
-	jb install && \
-	jsonnet -J vendor -S dashboards.jsonnet -m out/ && \
-	jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml && \
+	cd cortex-mixin
+	rm -rf out && mkdir out
+	jb install
+	jsonnet -J vendor -S dashboards.jsonnet -m out/
+	jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml
 	jsonnet -J vendor -S alerts.jsonnet > out/alerts.yaml
 	zip -r cortex-mixin.zip cortex-mixin/out
+test-readme:
+	rm -rf -- test-readme
+	GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
+	GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+	mkdir test-readme && cd test-readme
+	tk init --k8s=false
+	jb install github.com/jsonnet-libs/k8s-alpha/1.18
+	cat <<EOF > lib/k.libsonnet
+		(import "github.com/jsonnet-libs/k8s-alpha/1.18/main.libsonnet") +
+		(import "github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet")
+	EOF
+	jb install github.com/grafana/cortex-jsonnet/cortex
+	cp vendor/cortex/cortex-manifests.jsonnet.example environments/default/main.jsonnet
+	tk show environments/default

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-.PHONY: lint build-image publish-build-image
+.PHONY: lint build-image publish-build-image test-readme
 
 JSONNET_FMT := jsonnetfmt
 
 lint:
-	@RESULT=0;
-	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do
-		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -;
-		RESULT=$$(($$RESULT + $$?));
-	done;
+	@RESULT=0; \
+	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do \
+		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -; \
+		RESULT=$$(($$RESULT + $$?)); \
+	done; \
 	exit $$RESULT
 
 fmt:
-	@find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print |
+	@find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
 		xargs -n 1 -- $(JSONNET_FMT) -i
 
 build-image:
@@ -21,24 +21,20 @@ publish-build-image:
 	docker push grafana/cortex-jsonnet-build-image:$(shell git rev-parse --short HEAD)
 
 build-mixin:
-	cd cortex-mixin
-	rm -rf out && mkdir out
-	jb install
-	jsonnet -J vendor -S dashboards.jsonnet -m out/
-	jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml
+	cd cortex-mixin && \
+	rm -rf out && mkdir out && \
+	jb install && \
+	jsonnet -J vendor -S dashboards.jsonnet -m out/ && \
+	jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml && \
 	jsonnet -J vendor -S alerts.jsonnet > out/alerts.yaml
 	zip -r cortex-mixin.zip cortex-mixin/out
+
 test-readme:
-	rm -rf -- test-readme
-	GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
-	GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-	mkdir test-readme && cd test-readme
-	tk init --k8s=false
-	jb install github.com/jsonnet-libs/k8s-alpha/1.18
-	cat <<EOF > lib/k.libsonnet
-		(import "github.com/jsonnet-libs/k8s-alpha/1.18/main.libsonnet") +
-		(import "github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet")
-	EOF
-	jb install github.com/grafana/cortex-jsonnet/cortex
-	cp vendor/cortex/cortex-manifests.jsonnet.example environments/default/main.jsonnet
-	tk show environments/default
+	rm -rf test-readme && \
+	mkdir test-readme && cd test-readme && \
+	tk init --k8s=false && \
+	jb install github.com/jsonnet-libs/k8s-alpha/1.18 && \
+	printf '(import "github.com/jsonnet-libs/k8s-alpha/1.18/main.libsonnet")\n+(import "github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet")' > lib/k.libsonnet && \
+	jb install github.com/grafana/cortex-jsonnet/cortex && \
+	cp vendor/cortex/cortex-manifests.jsonnet.example environments/default/main.jsonnet && \
+	PAGER=cat tk show environments/default

--- a/README.md
+++ b/README.md
@@ -8,47 +8,47 @@ To generate the YAMLs for deploying Cortex:
 
     Follow the steps at https://tanka.dev/install. If you have `go` installed locally you can also use:
 
-    ```
-    # make sure to be outside of GOPATH or a go.mod project
+    ```console
+    $ # make sure to be outside of GOPATH or a go.mod project
     $ GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
     $ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
     ```
 
 1. Initialise the application and download the cortex jsonnet lib.
 
-    ```
+    ```console
     $ mkdir <name> && cd <name>
     $ tk init
     $ jb install github.com/grafana/cortex-jsonnet/cortex
     ```
 1. Use the example monitoring.jsonnet.example:
 
-    ```
+    ```console
     $ cp vendor/cortex/cortex-manifests.jsonnet.example environments/default/main.jsonnet
     ```
 
 1. Check what is in the example:
 
-    ```
+    ```console
     $ cat environments/default/main.jsonnet
     ...
     ```
 
 1. Generate the YAML manifests:
 
-    ```
+    ```console
     $ tk show environments/default
     ```
 
     To output YAML manifests to `./manifests`, run:
 
-    ```
+    ```console
     $ tk export environments/default manifests
     ```
 
     To generate the dashboards and alerts for Cortex:
 
-    ```
+    ```console
     $ cd cortex-mixin
     $ jb install
     $ mkdir out

--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ To generate the YAMLs for deploying Cortex:
     $ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
     ```
 
-1. Initialise the application and download the cortex jsonnet lib.
+1. Initialise the Tanka, and install the Cortex and Kubernetes Jsonnet libraries.
 
     ```console
     $ mkdir <name> && cd <name>
-    $ tk init
+    $ tk init --k8s=false
+    $ # The k8s-alpha library supports Kubernetes versions 1.14+
+    $ jb install github.com/jsonnet-libs/k8s-alpha/1.18
+    $ cat <<EOF > lib/k.libsonnet
+      (import "github.com/jsonnet-libs/k8s-alpha/1.18/main.libsonnet")
+      + (import "github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet")
+      EOF
     $ jb install github.com/grafana/cortex-jsonnet/cortex
     ```
 1. Use the example monitoring.jsonnet.example:

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -8,15 +8,16 @@ RUN git clone https://github.com/google/jsonnet && \
     cp jsonnet/jsonnetfmt /usr/bin
 
 # Build jb
-FROM golang:1.14.1-alpine3.11 AS jb-builder
-RUN apk add --no-cache git make
-RUN git clone https://github.com/jsonnet-bundler/jsonnet-bundler /jsonnet-bundler && \
-    cd /jsonnet-bundler && \
-    git checkout v0.2.0 && \
-    make install
+FROM alpine:3.11 AS jb-builder
+ARG JSONNET_BUNDLER_VERSION=0.4.0
+ARG JSONNET_BUNDLER_CHECKSUM="433edab5554a88a0371e11e93080408b225d41c31decf321c02b50d2e44993ce  /usr/bin/jb"
+RUN apk add --no-cache curl
+RUN curl -fSL -o "/usr/bin/jb" "https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v${JSONNET_BUNDLER_VERSION}/jb-linux-amd64"
+RUN echo "${JSONNET_BUNDLER_CHECKSUM}" | sha256sum -c || (printf "wanted: %s\n   got: %s\n" "${JSONNET_BUNDLER_CHECKSUM}" "$(sha256sum /usr/bin/jb)"; exit 1)
+RUN chmod +x /usr/bin/jb
 
 # Build tanka
-FROM golang:1.14.1-alpine3.11 as tk-builder
+FROM alpine:3.11 AS tk-builder
 ARG TANKA_VERSION=0.11.1
 ARG TANKA_CHECKSUM="3b253ca7d7bf01189604c10a8f7cead20a553ddc04c813f0f836d80338cfad71  /usr/bin/tk"
 RUN apk add --no-cache curl
@@ -28,5 +29,5 @@ FROM alpine:3.11
 RUN apk add --no-cache git make libgcc libstdc++ zip
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin
-COPY --from=jb-builder /go/bin/jb /usr/bin
+COPY --from=jb-builder /usr/bin/jb /usr/bin
 COPY --from=tk-builder /usr/bin/tk /usr/bin

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -15,8 +15,18 @@ RUN git clone https://github.com/jsonnet-bundler/jsonnet-bundler /jsonnet-bundle
     git checkout v0.2.0 && \
     make install
 
+# Build tanka
+FROM golang:1.14.1-alpine3.11 as tk-builder
+ARG TANKA_VERSION=0.11.1
+ARG TANKA_CHECKSUM="3b253ca7d7bf01189604c10a8f7cead20a553ddc04c813f0f836d80338cfad71  /usr/bin/tk"
+RUN apk add --no-cache curl
+RUN curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-amd64"
+RUN echo "${TANKA_CHECKSUM}" | sha256sum -c || (printf "wanted: %s\n   got: %s\n" "${TANKA_CHECKSUM}" "$(sha256sum /usr/bin/tk)"; exit 1)
+RUN chmod +x /usr/bin/tk
+
 FROM alpine:3.11
 RUN apk add --no-cache git make libgcc libstdc++ zip
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin
 COPY --from=jb-builder /go/bin/jb /usr/bin
+COPY --from=tk-builder /usr/bin/tk /usr/bin


### PR DESCRIPTION
- Updates the README to use the k8s-alpha Jsonnet lib which became a dependency after https://github.com/grafana/jsonnet-libs/pull/323/ was merged.
- Adds CI job to test the core of the README instructions.

Closes #98.
