### PR TITLE
Release 1.3.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+**What this PR does**:
+
+**Which issue(s) this PR fixes**:
+Fixes #<issue number>
+
+**Checklist**
+- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## master / unreleased
+
+## 1.3.0 / 2020-08-21
+
+This version is compatible with Cortex `1.3.0`.


### PR DESCRIPTION
Today I released Cortex 1.3.0 and, as described in the issue #159, I would like to start versioning the jsonnet with the same Cortex version.

Fixes #159