### PR TITLE
Fix annotation for CortexAllocatingTooMuchMemory

### DIFF
--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -383,7 +383,7 @@
           },
           annotations: {
             message: |||
-              Too much memory being used by {{ $labels.pod }} - add more ingesters.
+              Too much memory being used by {{ $labels.namespace }}/{{ $labels.pod }} - add more ingesters.
             |||,
           },
         },
@@ -402,7 +402,7 @@
           },
           annotations: {
             message: |||
-              Too much memory being used by {{ $labels.pod }} - add more ingesters.
+              Too much memory being used by {{ $labels.namespace }}/{{ $labels.pod }} - add more ingesters.
             |||,
           },
         },

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -383,7 +383,7 @@
           },
           annotations: {
             message: |||
-              Too much memory being used by {{ $labels.instance }} - add more ingesters.
+              Too much memory being used by {{ $labels.pod }} - add more ingesters.
             |||,
           },
         },
@@ -402,7 +402,7 @@
           },
           annotations: {
             message: |||
-              Too much memory being used by {{ $labels.instance }} - add more ingesters.
+              Too much memory being used by {{ $labels.pod }} - add more ingesters.
             |||,
           },
         },


### PR DESCRIPTION
Turns out `$labels.instance` is the node name in `container_memory_working_set_bytes`