### PR TITLE
Run AlertManager as a non-root user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] AlertManager libsonnet template uses a non-root user.
 * [CHANGE] The project is now licensed with Apache-2.0 license. #169
 * [CHANGE] Add overrides config to tsdb store-gateway. #167
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -43,7 +43,9 @@
       statefulSet.mixin.metadata.withLabels({ name: 'alertmanager' }) +
       statefulSet.mixin.spec.template.metadata.withLabels({ name: 'alertmanager' }) +
       statefulSet.mixin.spec.selector.withMatchLabels({ name: 'alertmanager' }) +
-      statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
+      statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(2000) +
+      statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(1000) +
+      statefulSet.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
       statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900)
     else {},


### PR DESCRIPTION
**What this PR does**:

AlertManager has been a non-root docker image for some time already, so
this should be a no-op change (see https://github.com/prometheus/alertmanager/issues/1585)

**Which issue(s) this PR fixes**:
Not reported as a bug.

**Checklist**
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`