### PR TITLE
Fix ruler S3 config option

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -143,7 +143,6 @@
         'experimental.tsdb.ship-interval': '1m',
         'experimental.tsdb.backend': 'gcs',
         'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
-        'experimental.tsdb.store-gateway-enabled': true,
         'experimental.store-gateway.sharding-enabled': true,
         'experimental.store-gateway.sharding-ring.store': 'consul',
         'experimental.store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -143,6 +143,7 @@
         'experimental.tsdb.ship-interval': '1m',
         'experimental.tsdb.backend': 'gcs',
         'experimental.tsdb.gcs.bucket-name': $._config.storage_tsdb_bucket_name,
+        'experimental.tsdb.store-gateway-enabled': true,
         'experimental.store-gateway.sharding-enabled': true,
         'experimental.store-gateway.sharding-ring.store': 'consul',
         'experimental.store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -224,7 +224,7 @@
           'ruler.storage.gcs.bucketname': $._config.ruler_gcs_bucket_name,
         },
         s3: {
-          's3.url': 'https://%s/%s' % [$._config.aws_region, $._config.s3_bucket_name],
+          's3.url': 'https://%s/%s' % [$._config.aws_region, $._config.ruler_s3_bucket_name],
         },
       }[$._config.ruler_client_type],
 


### PR DESCRIPTION
This looks like an oversight: the config defines `ruler_s3_bucket_name` just a few lines above this, but without this change it's never used.