### PR TITLE
Add support for local ruler_client_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [CHANGE] Add overrides config to tsdb store-gateway. #167
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
+* [BUGFIX] Add support the `local` ruler client type
 
 ## 1.3.0 / 2020-08-21
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -219,7 +219,7 @@
     },
 
     ruler_enabled: false,
-    ruler_client_type: error 'you must specify a storage backend type for the ruler (azure, configdb, gcs, s3)',
+    ruler_client_type: error 'you must specify a storage backend type for the ruler (azure, configdb, gcs, s3, local)',
     // TODO: Generic client generating functions would be nice.
     ruler_s3_bucket_name: $._config.s3_bucket_name,
     ruler_gcs_bucket_name: error 'must specify a GCS bucket name',
@@ -237,6 +237,9 @@
         },
         s3: {
           's3.url': 'https://%s/%s' % [$._config.aws_region, $._config.s3_bucket_name],
+        },
+        'local': {
+          'ruler.storage.local.directory': $._config.ruler_local_directory,
         },
       }[$._config.ruler_client_type],
 


### PR DESCRIPTION
**What this PR does**:
Adds support for the [`local` ruler client type](https://cortexmetrics.io/docs/configuration/configuration-file/#ruler_config). Seems like this was just missing before.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
