### PR TITLE
Ensure namespace is set on all Kubernetes resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
 * [BUGFIX] Add support the `local` ruler client type
-* [BUGFIX] Ensure namespaces are set on all kubernetes resources
+* [BUGFIX] Ensure namespaces are set on all kubernetes resources. #178 
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 
 ## 1.3.0 / 2020-08-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
 * [BUGFIX] Add support the `local` ruler client type
+* [BUGFIX] Ensure namespaces are set on all kubernetes resources
 
 ## 1.3.0 / 2020-08-21
 

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -54,6 +54,7 @@
 
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container], $.distributor_deployment_labels) +
+    deployment.mixin.metadata.withNamespace($._config.namespace) +
     $.util.antiAffinity +
     $.util.configVolumeMount('overrides', '/etc/cortex'),
 

--- a/cortex/memcached.libsonnet
+++ b/cortex/memcached.libsonnet
@@ -13,6 +13,7 @@ memcached {
         self.memcached_container,
         self.memcached_exporter,
       ], []) +
+      statefulSet.mixin.metadata.withNamespace($._config.namespace) +
       statefulSet.mixin.spec.withServiceName(self.name) +
       $.util.antiAffinity,
 

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -54,6 +54,7 @@
 
   querier_deployment:
     deployment.new('querier', $._config.querier.replicas, [$.querier_container], $.querier_deployment_labels) +
+    deployment.mixin.metadata.withNamespace($._config.namespace) +
     $.util.antiAffinity +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.storage_config_mixin,

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -65,6 +65,7 @@
 
   query_frontend_deployment:
     deployment.new('query-frontend', $._config.queryFrontend.replicas, [$.query_frontend_container]) +
+    deployment.mixin.metadata.withNamespace($._config.namespace) + 
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.util.antiAffinity +
     // inject storage schema in order to know what/how to shard

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -65,7 +65,7 @@
 
   query_frontend_deployment:
     deployment.new('query-frontend', $._config.queryFrontend.replicas, [$.query_frontend_container]) +
-    deployment.mixin.metadata.withNamespace($._config.namespace) + 
+    deployment.mixin.metadata.withNamespace($._config.namespace) +
     $.util.configVolumeMount('overrides', '/etc/cortex') +
     $.util.antiAffinity +
     // inject storage schema in order to know what/how to shard


### PR DESCRIPTION
**What this PR does**:

Ensure the namespace defined in _config is set on these resources:

- Distributor
- Memcached
- Querier
- Query-frontend
**Which issue(s) this PR fixes**:
Fixes #177  

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
