### PR TITLE
Fix typo in Alertmanager configuration and more tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * [CHANGE] Add overrides config to tsdb store-gateway. #167
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
+* [CHANGE] Alertmanager headless service uses a different name #179
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
+* [ENHANCEMENT] Support `alertmanager.fallback_config` option in the Alertmanager. #179
 
 ## 1.3.0 / 2020-08-21
 

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -47,7 +47,7 @@
       container.withArgsMixin(
         $.util.mapToFlags($.alertmanager_args) +
         if isHA then
-          ['--cluster.listen-address=[$(POD_IP)]:%s' % $._config.alertmanager_gossip_port] +
+          ['--cluster.listen-address=[$(POD_IP)]:%s' % $._config.alertmanager.gossip_port] +
           ['--cluster.peer=%s' % peer for peer in peers]
         else [],
       ) +

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -246,6 +246,7 @@
     alertmanager: {
       replicas: 3,
       gossip_port: 9094,
+      fallback_config: {},
     },
 
     overrides: {


### PR DESCRIPTION
This PR introduces three main things for our Alertmanager configuration:

- A small typo fix in the Alertmanager configuration `alertmanger.gossip_port` instead of `alertmanager_gossip_port`
- A new configuration options `fallback_config` to allow a fallback configuration to be specified.
- Uses a different name for the `headless-service`. The `ClusterIP` metadata field is immutable so we can't really update the spec of the service which makes it hard to switch between 1 and multiple replicas. 


**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
