### PR TITLE
Remove different name for a headless service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * [CHANGE] Add overrides config to tsdb store-gateway. #167
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yeild the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
-* [CHANGE] Alertmanager headless service uses a different name #179
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 * [ENHANCEMENT] Support `alertmanager.fallback_config` option in the Alertmanager. #179
 

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -99,10 +99,8 @@
     if $._config.alertmanager_enabled then
       if isHA then
         $.util.serviceFor($.alertmanager_statefulset) +
-        service.mixin.metadata.withName('alertmanager-headless') +
         service.mixin.spec.withClusterIp('None')
       else
-        $.util.serviceFor($.alertmanager_statefulset) +
-        service.mixin.metadata.withName('alertmanager')
+        $.util.serviceFor($.alertmanager_statefulset)
     else {},
 }


### PR DESCRIPTION
Sadly, we can't have a different name for the headless service as the
statefulset is configured to match its name.


It removes one of things introduced as part of #179 