### PR TITLE
Block Storage Support for S3/AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 * [ENHANCEMENT] Support `alertmanager.fallback_config` option in the Alertmanager. #179
+* [ENHANCEMENT] Add support for S3 block storage. #181
 * [BUGFIX] Add support the `local` ruler client type  #175
 * [BUGFIX] Fixes `ruler.storage.s3.url` argument for the Ruler. It used an incorrect argument. #177
 


### PR DESCRIPTION
Adds the setting `blocks_storage_backend` to allow switching between gcs and s3 for block storage. Feel free to critique the way I implemented it in jsonnet. Everyone has an opinion but I appreciate here that if I want to use azure I wouldn't need to add code here I could just add to `genericBlocksStorageConfig` and move on.

Closes #140, I tried to wait for it to complete. Fixes #166.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
