### PR TITLE
Added Azure support to blocks storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 * [ENHANCEMENT] Support `alertmanager.fallback_config` option in the Alertmanager. #179
 * [ENHANCEMENT] Add support for S3 block storage. #181
+* [ENHANCEMENT] Add support for Azure block storage. #182
 * [BUGFIX] Add support the `local` ruler client type  #175
 * [BUGFIX] Fixes `ruler.storage.s3.url` argument for the Ruler. It used an incorrect argument. #177
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -57,9 +57,11 @@
     // Use the Cortex chunks storage engine by default, while giving the ability
     // to switch to blocks storage.
     storage_engine: 'chunks',  // Available options are 'chunks' or 'blocks'
-    blocks_storage_backend: 'gcs',
+    blocks_storage_backend: 'gcs', // Available options are 'gcs', 's3', 'azure'
     blocks_storage_bucket_name: error 'must specify blocks storage bucket name',
     blocks_storage_s3_endpoint: 's3.dualstack.us-east-1.amazonaws.com',
+    blocks_storage_azure_account_name: if $._config.blocks_storage_backend == 'azure' then error 'must specify azure account name' else '',
+    blocks_storage_azure_account_key: if $._config.blocks_storage_backend == 'azure' then error 'must specify azure account key' else '',
 
     // Secondary storage engine is only used for querying.
     querier_second_storage_engine: null,
@@ -169,12 +171,19 @@
       'experimental.blocks-storage.s3.bucket-name': $._config.blocks_storage_bucket_name,
       'experimental.blocks-storage.s3.endpoint': $._config.blocks_storage_s3_endpoint,
     },
+    azureBlocksStorageConfig:: $._config.genericBlocksStorageConfig {
+      'experimental.blocks-storage.backend': 'azure',
+      'experimental.blocks-storage.azure.container-name': $._config.blocks_storage_bucket_name,
+      'experimental.blocks-storage.azure.account-name': $._config.blocks_storage_account_name,
+      'experimental.blocks-storage.azure.account-key': $._config.blocks_storage_account_key,
+    },
     // Blocks storage configuration, used only when 'blocks' storage
     // engine is explicitly enabled.
     blocksStorageConfig: (
       if $._config.storage_engine == 'blocks' || $._config.querier_second_storage_engine == 'blocks' then (
         if $._config.blocks_storage_backend == 'gcs' then $._config.gcsBlocksStorageConfig
         else if $._config.blocks_storage_backend == 's3' then $._config.s3BlocksStorageConfig
+        else if $._config.blocks_storage_backend == 'azure' then $._config.azureBlocksStorageConfig
         else $._config.genericBlocksStorageConfig
       ) else {}
     ),

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -57,7 +57,7 @@
     // Use the Cortex chunks storage engine by default, while giving the ability
     // to switch to blocks storage.
     storage_engine: 'chunks',  // Available options are 'chunks' or 'blocks'
-    blocks_storage_backend: 'gcs', // Available options are 'gcs', 's3', 'azure'
+    blocks_storage_backend: 'gcs',  // Available options are 'gcs', 's3', 'azure'
     blocks_storage_bucket_name: error 'must specify blocks storage bucket name',
     blocks_storage_s3_endpoint: 's3.dualstack.us-east-1.amazonaws.com',
     blocks_storage_azure_account_name: if $._config.blocks_storage_backend == 'azure' then error 'must specify azure account name' else '',


### PR DESCRIPTION
**What this PR does**:
Following up the work done in https://github.com/grafana/cortex-jsonnet/pull/181 to add S3 support, in this PR I'm adding Azure support for the blocks storage.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
