### PR TITLE
Removed the experimental prefix from blocks storage CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Ingesters now default to running as `StatefulSet` with WAL enabled. It is controlled by the config `$._config.ingester_deployment_without_wal` which is `false` by default. Setting the config to `true` will yield the old behaviour (stateless `Deployment` without WAL enabled). #72
 * [CHANGE] We now allow queries that are 32 days long. For example, rate(metric[32d]). Before it was 31d. #173
 * [CHANGE] Renamed `container_name` and `pod_name` label names to `container` and `pod` respectively. This is required in order to comply with cAdvisor metrics changes shipped with Kubernetes 1.16. #179
+* [CHANGE] Removed the `experimental` prefix from blocks storage CLI flags. #179
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 * [ENHANCEMENT] Support `alertmanager.fallback_config` option in the Alertmanager. #179
 * [ENHANCEMENT] Add support for S3 block storage. #181

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -148,34 +148,33 @@
 
     genericBlocksStorageConfig:: {
       'store.engine': $._config.storage_engine,  // May still be chunks
-      'experimental.blocks-storage.tsdb.dir': '/data/tsdb',
-      'experimental.blocks-storage.bucket-store.sync-dir': '/data/tsdb',
-      'experimental.blocks-storage.bucket-store.ignore-deletion-marks-delay': '1h',
-      'experimental.blocks-storage.tsdb.block-ranges-period': '2h',
-      'experimental.blocks-storage.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
-      'experimental.blocks-storage.tsdb.ship-interval': '1m',
+      'blocks-storage.tsdb.dir': '/data/tsdb',
+      'blocks-storage.bucket-store.sync-dir': '/data/tsdb',
+      'blocks-storage.bucket-store.ignore-deletion-marks-delay': '1h',
+      'blocks-storage.tsdb.block-ranges-period': '2h',
+      'blocks-storage.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
+      'blocks-storage.tsdb.ship-interval': '1m',
 
-      'experimental.store-gateway.sharding-enabled': true,
-      'experimental.store-gateway.sharding-ring.store': 'consul',
-      'experimental.store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
-      'experimental.store-gateway.sharding-ring.prefix': '',
-      'experimental.store-gateway.replication-factor': $._config.store_gateway_replication_factor,
-
+      'store-gateway.sharding-enabled': true,
+      'store-gateway.sharding-ring.store': 'consul',
+      'store-gateway.sharding-ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
+      'store-gateway.sharding-ring.prefix': '',
+      'store-gateway.replication-factor': $._config.store_gateway_replication_factor,
     },
     gcsBlocksStorageConfig:: $._config.genericBlocksStorageConfig {
-      'experimental.blocks-storage.backend': 'gcs',
-      'experimental.blocks-storage.gcs.bucket-name': $._config.blocks_storage_bucket_name,
+      'blocks-storage.backend': 'gcs',
+      'blocks-storage.gcs.bucket-name': $._config.blocks_storage_bucket_name,
     },
     s3BlocksStorageConfig:: $._config.genericBlocksStorageConfig {
-      'experimental.blocks-storage.backend': 's3',
-      'experimental.blocks-storage.s3.bucket-name': $._config.blocks_storage_bucket_name,
-      'experimental.blocks-storage.s3.endpoint': $._config.blocks_storage_s3_endpoint,
+      'blocks-storage.backend': 's3',
+      'blocks-storage.s3.bucket-name': $._config.blocks_storage_bucket_name,
+      'blocks-storage.s3.endpoint': $._config.blocks_storage_s3_endpoint,
     },
     azureBlocksStorageConfig:: $._config.genericBlocksStorageConfig {
-      'experimental.blocks-storage.backend': 'azure',
-      'experimental.blocks-storage.azure.container-name': $._config.blocks_storage_bucket_name,
-      'experimental.blocks-storage.azure.account-name': $._config.blocks_storage_account_name,
-      'experimental.blocks-storage.azure.account-key': $._config.blocks_storage_account_key,
+      'blocks-storage.backend': 'azure',
+      'blocks-storage.azure.container-name': $._config.blocks_storage_bucket_name,
+      'blocks-storage.azure.account-name': $._config.blocks_storage_account_name,
+      'blocks-storage.azure.account-key': $._config.blocks_storage_account_key,
     },
     // Blocks storage configuration, used only when 'blocks' storage
     // engine is explicitly enabled.

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -29,35 +29,35 @@
   blocks_chunks_caching_config::
     (
       if $._config.memcached_index_queries_enabled then {
-        'experimental.blocks-storage.bucket-store.index-cache.backend': 'memcached',
-        'experimental.blocks-storage.bucket-store.index-cache.memcached.addresses': 'dnssrvnoa+memcached-index-queries.%(namespace)s.svc.cluster.local:11211' % $._config,
-        'experimental.blocks-storage.bucket-store.index-cache.memcached.timeout': '200ms',
-        'experimental.blocks-storage.bucket-store.index-cache.memcached.max-item-size': $._config.memcached_index_queries_max_item_size_mb * 1024 * 1024,
-        'experimental.blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size': '25000',
-        'experimental.blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency': '50',
-        'experimental.blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size': '100',
-        'experimental.blocks-storage.bucket-store.index-cache.postings-compression-enabled': 'true',
+        'blocks-storage.bucket-store.index-cache.backend': 'memcached',
+        'blocks-storage.bucket-store.index-cache.memcached.addresses': 'dnssrvnoa+memcached-index-queries.%(namespace)s.svc.cluster.local:11211' % $._config,
+        'blocks-storage.bucket-store.index-cache.memcached.timeout': '200ms',
+        'blocks-storage.bucket-store.index-cache.memcached.max-item-size': $._config.memcached_index_queries_max_item_size_mb * 1024 * 1024,
+        'blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size': '25000',
+        'blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency': '50',
+        'blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size': '100',
+        'blocks-storage.bucket-store.index-cache.postings-compression-enabled': 'true',
       } else {}
     ) + (
       if $._config.memcached_chunks_enabled then {
-        'experimental.blocks-storage.bucket-store.chunks-cache.backend': 'memcached',
-        'experimental.blocks-storage.bucket-store.chunks-cache.memcached.addresses': 'dnssrvnoa+memcached.%(namespace)s.svc.cluster.local:11211' % $._config,
-        'experimental.blocks-storage.bucket-store.chunks-cache.memcached.timeout': '200ms',
-        'experimental.blocks-storage.bucket-store.chunks-cache.memcached.max-item-size': $._config.memcached_chunks_max_item_size_mb * 1024 * 1024,
-        'experimental.blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size': '25000',
-        'experimental.blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency': '50',
-        'experimental.blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size': '100',
+        'blocks-storage.bucket-store.chunks-cache.backend': 'memcached',
+        'blocks-storage.bucket-store.chunks-cache.memcached.addresses': 'dnssrvnoa+memcached.%(namespace)s.svc.cluster.local:11211' % $._config,
+        'blocks-storage.bucket-store.chunks-cache.memcached.timeout': '200ms',
+        'blocks-storage.bucket-store.chunks-cache.memcached.max-item-size': $._config.memcached_chunks_max_item_size_mb * 1024 * 1024,
+        'blocks-storage.bucket-store.chunks-cache.memcached.max-async-buffer-size': '25000',
+        'blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency': '50',
+        'blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-batch-size': '100',
       } else {}
     ),
 
   blocks_metadata_caching_config:: if $._config.memcached_metadata_enabled then {
-    'experimental.blocks-storage.bucket-store.metadata-cache.backend': 'memcached',
-    'experimental.blocks-storage.bucket-store.metadata-cache.memcached.addresses': 'dnssrvnoa+memcached-metadata.%(namespace)s.svc.cluster.local:11211' % $._config,
-    'experimental.blocks-storage.bucket-store.metadata-cache.memcached.timeout': '200ms',
-    'experimental.blocks-storage.bucket-store.metadata-cache.memcached.max-item-size': $._config.memcached_metadata_max_item_size_mb * 1024 * 1024,
-    'experimental.blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size': '25000',
-    'experimental.blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency': '50',
-    'experimental.blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size': '100',
+    'blocks-storage.bucket-store.metadata-cache.backend': 'memcached',
+    'blocks-storage.bucket-store.metadata-cache.memcached.addresses': 'dnssrvnoa+memcached-metadata.%(namespace)s.svc.cluster.local:11211' % $._config,
+    'blocks-storage.bucket-store.metadata-cache.memcached.timeout': '200ms',
+    'blocks-storage.bucket-store.metadata-cache.memcached.max-item-size': $._config.memcached_metadata_max_item_size_mb * 1024 * 1024,
+    'blocks-storage.bucket-store.metadata-cache.memcached.max-async-buffer-size': '25000',
+    'blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency': '50',
+    'blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-batch-size': '100',
   } else {},
 
   querier_args+:: $.blocks_metadata_caching_config,
@@ -176,7 +176,7 @@
 
       // Persist ring tokens so that when the store-gateway will be restarted
       // it will pick the same tokens
-      'experimental.store-gateway.tokens-file-path': '/data/tokens',
+      'store-gateway.tokens-file-path': '/data/tokens',
     } + $.blocks_chunks_caching_config + $.blocks_metadata_caching_config,
 
   store_gateway_ports:: $.util.defaultPorts,


### PR DESCRIPTION
**What this PR does**:
In preparation for the Cortex 1.4.0 release, I'm removing the `experimental` prefix from blocks storage CLI flags.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
