### PR TITLE
Fixed Azure account name/key config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [ENHANCEMENT] Enable support for HA in the Cortex Alertmanager #147
 * [ENHANCEMENT] Support `alertmanager.fallback_config` option in the Alertmanager. #179
 * [ENHANCEMENT] Add support for S3 block storage. #181
-* [ENHANCEMENT] Add support for Azure block storage. #182
+* [ENHANCEMENT] Add support for Azure block storage. #182 #190
 * [BUGFIX] Add support the `local` ruler client type  #175
 * [BUGFIX] Fixes `ruler.storage.s3.url` argument for the Ruler. It used an incorrect argument. #177
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -173,8 +173,8 @@
     azureBlocksStorageConfig:: $._config.genericBlocksStorageConfig {
       'blocks-storage.backend': 'azure',
       'blocks-storage.azure.container-name': $._config.blocks_storage_bucket_name,
-      'blocks-storage.azure.account-name': $._config.blocks_storage_account_name,
-      'blocks-storage.azure.account-key': $._config.blocks_storage_account_key,
+      'blocks-storage.azure.account-name': $._config.blocks_storage_azure_account_name,
+      'blocks-storage.azure.account-key': $._config.blocks_storage_azure_account_key,
     },
     // Blocks storage configuration, used only when 'blocks' storage
     // engine is explicitly enabled.


### PR DESCRIPTION
**What this PR does**:
The config properties for the Azure account were supposed to be `blocks_storage_azure_account_name` and `blocks_storage_azure_account_key`, but I did a mistake in #182.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
