### PR TITLE
Make sure only a single ruler rolls out at a time

### DIFF
--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -36,6 +36,8 @@
   ruler_deployment:
     if $._config.ruler_enabled then
       deployment.new('ruler', 2, [$.ruler_container]) +
+      deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
+      deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
       $.util.antiAffinity +
       $.util.configVolumeMount('overrides', '/etc/cortex') +


### PR DESCRIPTION
The ruler is part of the ring and I think should avoid large reshardings during rollouts.