### PR TITLE
Use mixtool to build and lint the mixin.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run: make build-mixin
       - store_artifacts:
-          path: cortex-mixin.zip
+          path: cortex-mixin/cortex-mixin.zip
   test-readme:
     docker:
       - image: grafana/cortex-jsonnet-build-image:8ce0de1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:55f5699
+      - image: grafana/cortex-jsonnet-build-image:8ce0de1
     steps:
       - checkout
       - run: make lint
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:55f5699
+      - image: grafana/cortex-jsonnet-build-image:8ce0de1
     steps:
       - checkout
       - run: make build-mixin
@@ -26,7 +26,7 @@ jobs:
           path: cortex-mixin.zip
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:55f5699
+      - image: grafana/cortex-jsonnet-build-image:8ce0de1
     steps:
       - checkout
       - run: make test-readme

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ lint:
 		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -; \
 		RESULT=$$(($$RESULT + $$?)); \
 	done; \
+	pushd cortex-mixin >/dev/null && jb install && popd >/dev/null; \
+	mixtool lint -J cortex-mixin/vendor cortex-mixin/mixin.libsonnet; \
+	RESULT=$$(($$RESULT + $$?)); \
 	exit $$RESULT
 
 fmt:
@@ -24,10 +27,8 @@ build-mixin:
 	cd cortex-mixin && \
 	rm -rf out && mkdir out && \
 	jb install && \
-	jsonnet -J vendor -S dashboards.jsonnet -m out/ && \
-	jsonnet -J vendor -S recording_rules.jsonnet > out/rules.yaml && \
-	jsonnet -J vendor -S alerts.jsonnet > out/alerts.yaml
-	zip -r cortex-mixin.zip cortex-mixin/out
+	mixtool generate all --output-alerts out/alerts.yaml --output-rules out/rules.yaml --directory out/dashboards mixin.libsonnet && \
+	zip -r cortex-mixin.zip out
 
 test-readme:
 	rm -rf test-readme && \

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,18 @@
 
 JSONNET_FMT := jsonnetfmt
 
-lint:
+lint: lint-mixin
 	@RESULT=0; \
 	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do \
 		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -; \
 		RESULT=$$(($$RESULT + $$?)); \
 	done; \
-	pushd cortex-mixin >/dev/null && jb install && popd >/dev/null; \
-	mixtool lint -J cortex-mixin/vendor cortex-mixin/mixin.libsonnet; \
 	RESULT=$$(($$RESULT + $$?)); \
-	exit $$RESULT
+
+lint-mixin:
+	cd cortex-mixin && \
+	jb install && \
+	mixtool lint mixin.libsonnet
 
 fmt:
 	@find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -25,9 +25,14 @@ RUN curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/downlo
 RUN echo "${TANKA_CHECKSUM}" | sha256sum -c || (printf "wanted: %s\n   got: %s\n" "${TANKA_CHECKSUM}" "$(sha256sum /usr/bin/tk)"; exit 1)
 RUN chmod +x /usr/bin/tk
 
+# Build mixtool
+FROM golang:1.15-alpine AS mixtool-builder
+RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@59d44357240d
+
 FROM alpine:3.11
 RUN apk add --no-cache git make libgcc libstdc++ zip
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin
 COPY --from=jb-builder /usr/bin/jb /usr/bin
 COPY --from=tk-builder /usr/bin/tk /usr/bin
+COPY --from=mixtool-builder /go/bin/mixtool /usr/bin

--- a/cortex-mixin/alerts.jsonnet
+++ b/cortex-mixin/alerts.jsonnet
@@ -1,3 +1,0 @@
-local mixin = import 'mixin.libsonnet';
-
-std.manifestYamlDoc(mixin.prometheusAlerts)

--- a/cortex-mixin/dashboards.jsonnet
+++ b/cortex-mixin/dashboards.jsonnet
@@ -1,6 +1,0 @@
-local mixin = import 'mixin.libsonnet';
-
-{
-  [name]: std.manifestJsonEx(mixin.grafanaDashboards[name], ' ')
-  for name in std.objectFields(mixin.grafanaDashboards)
-}

--- a/cortex-mixin/dashboards/chunks.libsonnet
+++ b/cortex-mixin/dashboards/chunks.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-chunks.json':
-    $.dashboard('Cortex / Chunks')
+    ($.dashboard('Cortex / Chunks') + { uid: 'a56a3fa6284064eb392a115f3acbf744' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Active Series / Chunks')
@@ -52,7 +52,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ),
 
   'cortex-wal.json':
-    $.dashboard('Cortex / WAL')
+    ($.dashboard('Cortex / WAL') + { uid: 'd4fb924cdc1581cd8e870e3eb0110bda' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('')

--- a/cortex-mixin/dashboards/compactor-resources.libsonnet
+++ b/cortex-mixin/dashboards/compactor-resources.libsonnet
@@ -6,7 +6,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ignoring(pod) group_right() (label_replace(count by(pod, instance, device) (container_fs_writes_bytes_total{%s,container="compactor",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
     ||| % $.namespaceMatcher();
 
-    $.dashboard('Cortex / Compactor Resources')
+    ($.dashboard('Cortex / Compactor Resources') + { uid: 'df9added6f1f4332f95848cca48ebd99' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('CPU and Memory')

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-compactor.json':
-    $.dashboard('Cortex / Compactor')
+    ($.dashboard('Cortex / Compactor') + { uid: '9c408e1d55681ecb8a22c9fab46875cc' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Compactions')

--- a/cortex-mixin/dashboards/comparison.libsonnet
+++ b/cortex-mixin/dashboards/comparison.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet')
 {
   'cortex-blocks-vs-chunks.json':
-    $.dashboard('Cortex / Blocks vs Chunks')
+    ($.dashboard('Cortex / Blocks vs Chunks') + { uid: '0e2b4dd23df9921972e3fb554c0fc483' })
     .addMultiTemplate('cluster', 'kube_pod_container_info{image=~".*cortex.*"}', 'cluster')
     .addTemplate('blocks_namespace', 'kube_pod_container_info{image=~".*cortex.*"}', 'namespace')
     .addTemplate('chunks_namespace', 'kube_pod_container_info{image=~".*cortex.*"}', 'namespace')

--- a/cortex-mixin/dashboards/config.libsonnet
+++ b/cortex-mixin/dashboards/config.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
 
   'cortex-config.json':
-    $.dashboard('Cortex / Config')
+    ($.dashboard('Cortex / Config') + { uid: '61bb048ced9817b2d3e07677fb1c6290' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Startup config file')

--- a/cortex-mixin/dashboards/object-store.libsonnet
+++ b/cortex-mixin/dashboards/object-store.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-object-store.json':
-    $.dashboard('Cortex / Object Store')
+    ($.dashboard('Cortex / Object Store') + { uid: 'd5a3a4489d57c733b5677fb55370a723' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Components')

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
 
   'cortex-queries.json':
-    $.dashboard('Cortex / Queries')
+    ($.dashboard('Cortex / Queries') + { uid: 'd9931b1054053c8b972d320774bb8f1d' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Query Frontend')

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-reads-resources.json':
-    $.dashboard('Cortex / Reads Resources')
+    ($.dashboard('Cortex / Reads Resources') + { uid: '2fd2cda9eea8d8af9fbc0a5960425120' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Gateway')

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-reads.json':
-    $.dashboard('Cortex / Reads')
+    ($.dashboard('Cortex / Reads') + { uid: '8d6ba60eccc4b6eedfa329b24b1bd339' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Gateway')

--- a/cortex-mixin/dashboards/ruler.libsonnet
+++ b/cortex-mixin/dashboards/ruler.libsonnet
@@ -30,7 +30,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   'ruler.json':
-    $.dashboard('Cortex / Ruler')
+    ($.dashboard('Cortex / Ruler') + { uid: '44d12bcb1f95661c6ab6bc946dfc3473' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Rule Evaluations')

--- a/cortex-mixin/dashboards/scaling.libsonnet
+++ b/cortex-mixin/dashboards/scaling.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
 
   'cortex-scaling.json':
-    $.dashboard('Cortex / Scaling')
+    ($.dashboard('Cortex / Scaling') + { uid: '88c041017b96856c9176e07cf557bdcf' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Workload-based scaling')

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-writes-resources.json':
-    $.dashboard('Cortex / Writes Resources')
+    ($.dashboard('Cortex / Writes Resources') + { uid: 'c0464f0d8bd026f776c9006b0591bb0b' })
     .addClusterSelectorTemplates()
     .addRow(
       $.row('Gateway')

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -2,7 +2,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-writes.json':
-    $.dashboard('Cortex / Writes')
+    ($.dashboard('Cortex / Writes') + { uid: '0156f6d15aa234d452a33a4f13c838e3' })
     .addClusterSelectorTemplates()
     .addRow(
       ($.row('Headlines') +

--- a/cortex-mixin/jsonnetfile.json
+++ b/cortex-mixin/jsonnetfile.json
@@ -1,24 +1,24 @@
 {
+  "version": 1,
   "dependencies": [
     {
-      "name": "grafana-builder",
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "grafana-builder"
         }
       },
       "version": "master"
     },
     {
-      "name": "mixin-utils",
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "mixin-utils"
         }
       },
       "version": "master"
     }
-  ]
+  ],
+  "legacyImports": true
 }

--- a/cortex-mixin/recording_rules.jsonnet
+++ b/cortex-mixin/recording_rules.jsonnet
@@ -1,1 +1,0 @@
-std.manifestYamlDoc((import 'mixin.libsonnet').prometheusRules)


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

**What this PR does**:

Uses the `mixtool` tool to lint and build the mixin.

Adds dashboards UIDs based on the md5 of their filename, as prometheus-ksonnet does.
