### PR TITLE
Add ingester-blocks to ingester's job label matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
 * [FEATURE] Latency recording rules for the metric`cortex_querier_request_duration_seconds` are now part of a `cortex_querier_api` rule group. #199
 * [FEATURE] Add overrides-exporter as optional deployment to expose configured runtime overrides and presets. #198
+* [BUGFIX] Added `ingester-blocks` to ingester's job label matcher, in order to correctly get metrics when migrating a Cortex cluster from chunks to blocks. #203
 
 ## 1.4.0 / 2020-10-02
 

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -26,7 +26,7 @@
     // These are used by the dashboards and allow for the simultaneous display of
     // microservice and single binary cortex clusters.
     job_names: {
-      ingester: '(ingester|ingester-blocks|cortex$)',  // Match also ingester-blocks, which is used during the migration from chunks to blocks.
+      ingester: '(ingester.*|cortex$)',  // Match also ingester-blocks, which is used during the migration from chunks to blocks.
       distributor: '(distributor|cortex$)',
       querier: '(querier|cortex$)',
       query_frontend: '(query-frontend|cortex$)',

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -26,7 +26,7 @@
     // These are used by the dashboards and allow for the simultaneous display of
     // microservice and single binary cortex clusters.
     job_names: {
-      ingester: '(ingester|cortex$)',
+      ingester: '(ingester|ingester-blocks|cortex$)',  // Match also ingester-blocks, which is used during the migration from chunks to blocks.
       distributor: '(distributor|cortex$)',
       querier: '(querier|cortex$)',
       query_frontend: '(query-frontend|cortex$)',


### PR DESCRIPTION
**What this PR does**:
When we migrate a Cortex cluster from chunks to blocks, the migration procedure involves creating a temporary statefulset named `ingester-blocks`. Because of this, during the migration we loose visibility over ingesters.

What's the sentiment adding `ingester-blocks` too to default job names?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
