### PR TITLE
Add the ruler to the read resources dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Add the default preset 'extra_small_user' and reference it in the CLI flags. This will raise the limits of the 'small_user' preset to the defaults for `ingester.max-samples-per-query` and `ingester.max-series-per-query`. #200
+* [ENHANCEMENT] Add the Ruler to the write resources dashboard #XXX
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
 * [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications and per user per rule group evaluation. #197
 * [FEATURE] Latency recording rules for the metric`cortex_querier_request_duration_seconds` are now part of a `cortex_querier_api` rule group. #199

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## master / unreleased
 
 * [CHANGE] Add the default preset 'extra_small_user' and reference it in the CLI flags. This will raise the limits of the 'small_user' preset to the defaults for `ingester.max-samples-per-query` and `ingester.max-series-per-query`. #200
-* [ENHANCEMENT] Add the Ruler to the write resources dashboard #205
+* [ENHANCEMENT] Add the Ruler to the read resources dashboard #205
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
-* [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications and per user per rule group evaluation. #197, #205
+* [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications, reads/writes, and per user per rule group evaluation. #197, #205
 * [FEATURE] Latency recording rules for the metric`cortex_querier_request_duration_seconds` are now part of a `cortex_querier_api` rule group. #199
 * [FEATURE] Add overrides-exporter as optional deployment to expose configured runtime overrides and presets. #198
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Add the default preset 'extra_small_user' and reference it in the CLI flags. This will raise the limits of the 'small_user' preset to the defaults for `ingester.max-samples-per-query` and `ingester.max-series-per-query`. #200
-* [ENHANCEMENT] Add the Ruler to the write resources dashboard #XXX
+* [ENHANCEMENT] Add the Ruler to the write resources dashboard #205
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
 * [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications and per user per rule group evaluation. #197
 * [FEATURE] Latency recording rules for the metric`cortex_querier_request_duration_seconds` are now part of a `cortex_querier_api` rule group. #199

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [CHANGE] Add the default preset 'extra_small_user' and reference it in the CLI flags. This will raise the limits of the 'small_user' preset to the defaults for `ingester.max-samples-per-query` and `ingester.max-series-per-query`. #200
 * [ENHANCEMENT] Add the Ruler to the write resources dashboard #205
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
-* [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications and per user per rule group evaluation. #197
+* [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications and per user per rule group evaluation. #197, #205
 * [FEATURE] Latency recording rules for the metric`cortex_querier_request_duration_seconds` are now part of a `cortex_querier_api` rule group. #199
 * [FEATURE] Add overrides-exporter as optional deployment to expose configured runtime overrides and presets. #198
 

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -29,6 +29,7 @@
       ingester: '(ingester|cortex$)',
       distributor: '(distributor|cortex$)',
       querier: '(querier|cortex$)',
+      ruler: '(ruler|cortex$)',
       query_frontend: '(query-frontend|cortex$)',
       table_manager: '(table-manager|cortex$)',
       store_gateway: '(store-gateway|cortex$)',

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -52,6 +52,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
       )
     )
+    .addRow(
+      $.row('Ruler')
+      .addPanel(
+        $.panel('Rules') +
+        $.queryPanel('sum by(instance) (cortex_prometheus_rule_group_rules{%s})' % $.jobMatcher($._config.job_names.ruler), '{{instance}}'),
+      )
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'ruler'),
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
+      )
+    )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway')

--- a/cortex-mixin/dashboards/ruler.libsonnet
+++ b/cortex-mixin/dashboards/ruler.libsonnet
@@ -75,11 +75,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.statPanel('sum(cortex_prometheus_rule_group_rules{%s})' % $.jobMatcher('ruler'), format='short')
       )
       .addPanel(
-        $.panel('Read QPS') +
+        $.panel('Read from Ingesters - QPS') +
         $.statPanel('sum(rate(cortex_ingester_client_request_duration_seconds_count{%s, operation="/cortex.Ingester/QueryStream"}[5m]))' % $.jobMatcher('ruler'), format='reqps')
       )
       .addPanel(
-        $.panel('Write QPS') +
+        $.panel('Write to Ingesters - QPS') +
         $.statPanel('sum(rate(cortex_ingester_client_request_duration_seconds_count{%s, operation="/cortex.Ingester/Push"}[5m]))' % $.jobMatcher('ruler'), format='reqps')
       )
     )
@@ -115,25 +115,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      $.row('Writes')
+      $.row('Writes (Ingesters)')
       .addPanel(
         $.panel('QPS') +
         $.qpsPanel('cortex_ingester_client_request_duration_seconds_count{%s, operation="/cortex.Ingester/Push"}' % $.jobMatcher('ruler'))
       )
       .addPanel(
         $.panel('Latency') +
-        $.latencyPanel('cortex_ingester_client_request_duration_seconds', '{%s, operation="/cortex.Ingester/Push"}' % $.jobSelector('ruler'))
+        $.latencyPanel('cortex_ingester_client_request_duration_seconds', '{%s, operation="/cortex.Ingester/Push"}' % $.jobMatcher('ruler'))
       )
     )
     .addRow(
-      $.row('Reads')
+      $.row('Reads (Ingesters)')
       .addPanel(
         $.panel('QPS') +
         $.qpsPanel('cortex_ingester_client_request_duration_seconds_count{%s, operation="/cortex.Ingester/QueryStream"}' % $.jobMatcher('ruler'))
       )
       .addPanel(
         $.panel('Latency') +
-        $.latencyPanel('cortex_ingester_client_request_duration_seconds', '{%s, operation="/cortex.Ingester/QueryStream"}' % $.jobSelector('ruler'))
+        $.latencyPanel('cortex_ingester_client_request_duration_seconds', '{%s, operation="/cortex.Ingester/QueryStream"}' % $.jobMatcher('ruler'))
       )
     )
     .addRow(

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -47,25 +47,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
       )
     )
-    .addRow(
-      $.row('Ruler')
-      .addPanel(
-        $.panel('Rules') +
-        $.queryPanel('sum by(instance) (cortex_prometheus_rule_group_rules{%s})' % $.jobMatcher($._config.job_names.ruler), '{{instance}}'),
-      )
-      .addPanel(
-        $.containerCPUUsagePanel('CPU', 'ruler'),
-      )
-    )
-    .addRow(
-      $.row('')
-      .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
-      )
-      .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
-      )
-    ) + {
+    + {
       templating+: {
         list: [
           // Do not allow to include all clusters/namespaces otherwise this dashboard

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -46,6 +46,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
       )
+    )
+    .addRow(
+      $.row('Ruler')
+      .addPanel(
+        $.panel('Rules') +
+        $.queryPanel('sum by(instance) (cortex_prometheus_rule_group_rules{%s})' % $.jobMatcher($._config.job_names.ruler), '{{instance}}'),
+      )
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'ruler'),
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
+      )
     ) + {
       templating+: {
         list: [


### PR DESCRIPTION
**What this PR does**:

Adds the ruler to the write resources dashboard. Technically the ruler is both a read/write resources but it felt more compelling to the add the write than the read. 

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
