### PR TITLE
Removed support for ingester.statefulset_replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## master / unreleased
 
 * [CHANGE] Add the default preset 'extra_small_user' and reference it in the CLI flags. This will raise the limits of the 'small_user' preset to the defaults for `ingester.max-samples-per-query` and `ingester.max-series-per-query`. #200
+* [CHANGE] Removed the config option `$._config.ingester.statefulset_replicas` which was used only when running Cortex chunks storage with WAL enabled. To configure the number of ingester replicas you should now use the following: #210
+  ```
+  ingester_statefulset+:
+      statefulSet.mixin.spec.withReplicas(6),
+  ```
 * [ENHANCEMENT] Add the Ruler to the read resources dashboard #205
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
 * [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications, reads/writes, and per user per rule group evaluation. #197, #205

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -75,7 +75,6 @@
     ingester: {
       // These config options are only for the chunks storage.
       wal_dir: '/wal_data',
-      statefulset_replicas: 3,
       statefulset_disk: '150Gi',
     },
 

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -91,7 +91,7 @@
 
   ingester_statefulset:
     if $._config.ingester_deployment_without_wal == false then
-      statefulSet.new('ingester', $._config.ingester.statefulset_replicas, [$.ingester_statefulset_container], ingester_pvc) +
+      statefulSet.new('ingester', 3, [$.ingester_statefulset_container], ingester_pvc) +
       statefulSet.mixin.spec.withServiceName('ingester') +
       statefulSet.mixin.spec.template.spec.withVolumes([volume.fromPersistentVolumeClaim('ingester-pvc', 'ingester-pvc')]) +
       statefulSet.mixin.metadata.withNamespace($._config.namespace) +


### PR DESCRIPTION
**What this PR does**:
The issue #209 make me realise the chunks storage with WAL enabled is using a pattern different than any other place in our jsonnet to configure the number of replicas. Instead of fixing #209 applying the config option to blocks storage too, I'm proposing to remove that config option at all, because it's looks like breaking our config consistency.

**Which issue(s) this PR fixes**:
Fixes #209

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
