### PR TITLE
Switch compactor statefulset to Parallel pod management policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   ingester_statefulset+:
       statefulSet.mixin.spec.withReplicas(6),
   ```
+* [CHANGE] The compactor statefulset is now configured with the `Parallel` pod management policy, in order to scale up quickly. #214
 * [ENHANCEMENT] Add the Ruler to the read resources dashboard #205
 * [ENHANCEMENT] Read dashboards now use `cortex_querier_request_duration_seconds` metrics to allow for accurate dashboards when deploying Cortex as a single-binary. #199
 * [ENHANCEMENT] Improved Ruler dashboard. Includes information about notifications, reads/writes, and per user per rule group evaluation. #197, #205

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -157,7 +157,12 @@
     statefulSet.mixin.spec.selector.withMatchLabels({ name: 'compactor' }) +
     statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900),
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
+    // Parallelly scale up/down compactor instances instead of starting them
+    // one by one. This does NOT affect rolling updates: they will continue to be
+    // rolled out one by one (the next pod will be rolled out once the previous is
+    // ready).
+    statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
 
   // The store-gateway runs a statefulset.
   local store_gateway_data_pvc =


### PR DESCRIPTION
**What this PR does**:
Contrary to ingesters and store-gateways, the compactor didn't have the `Parallel` pod management policy, to scale up quickly. In this PR I'm changing it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
