### PR TITLE
Cut 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+## 1.5.0 / 2020-11-12
+
 * [CHANGE] Add the default preset 'extra_small_user' and reference it in the CLI flags. This will raise the limits of the 'small_user' preset to the defaults for `ingester.max-samples-per-query` and `ingester.max-series-per-query`. #200
 * [CHANGE] Removed the config option `$._config.ingester.statefulset_replicas` which was used only when running Cortex chunks storage with WAL enabled. To configure the number of ingester replicas you should now use the following: #210
   ```

--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -5,7 +5,7 @@
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.
-    cortex: 'cortexproject/cortex:v1.4.0',
+    cortex: 'cortexproject/cortex:v1.5.0',
 
     alertmanager: self.cortex,
     distributor: self.cortex,


### PR DESCRIPTION
**What this PR does**:
Now that Cortex 1.5.0 has been released, we can cut 1.5.0 for jsonnet too.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
