### PR TITLE
Enabled compactor sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## master / unreleased
 
-* [ENHANCEMENT] Introduce a resources dashboard for the Alertmanager #218
 * [CHANGE] Add default present for ruler limits on all 'user' types. #213
+* [CHANGE] Enabled sharding for the blocks storage compactor. #218
+* [ENHANCEMENT] Introduce a resources dashboard for the Alertmanager. #219
 
 ## 1.5.0 / 2020-11-12
 

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -134,6 +134,12 @@
       'compactor.data-dir': '/data',
       'compactor.compaction-interval': '30m',
       'compactor.compaction-concurrency': $._config.cortex_compactor_max_concurrency,
+
+      // Enable sharding.
+      'compactor.sharding-enabled': true,
+      'compactor.ring.store': 'consul',
+      'compactor.ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
+      'compactor.ring.prefix': '',
     },
 
   compactor_ports:: $.util.defaultPorts,


### PR DESCRIPTION
**What this PR does**:
Contrary to all other services supporting sharding, compactor sharding was not enabled in our jsonnet. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
