### PR TITLE
[fixup] ruler limits config key name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [CHANGE] Add default present for ruler limits on all 'user' types. #221
+* [CHANGE] Add default present for ruler limits on all 'user' types. #221, #222
 * [CHANGE] Enabled sharding for the blocks storage compactor. #218
 * [ENHANCEMENT] Introduce a resources dashboard for the Alertmanager. #219
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -295,8 +295,8 @@
         ingestion_burst_size: 200000,
 
         // 300 rules
-        max_rules_per_rule_group: 15,
-        max_rule_groups_per_tenant: 20,
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 20,
       },
 
       small_user:: {
@@ -313,8 +313,8 @@
         ingestion_burst_size: 1000000,
 
         // 450 rules
-        max_rules_per_rule_group: 15,
-        max_rule_groups_per_tenant: 30,
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 30,
       },
 
       medium_user:: {
@@ -331,8 +331,8 @@
         ingestion_burst_size: 3500000,  // 3.5M
 
         // 600 rules
-        max_rules_per_rule_group: 15,
-        max_rule_groups_per_tenant: 40,
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 40,
       },
 
       big_user:: {
@@ -349,8 +349,8 @@
         ingestion_burst_size: 7000000,  // 7M
 
         // 750 rules
-        max_rules_per_rule_group: 15,
-        max_rule_groups_per_tenant: 50,
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 50,
       },
 
       super_user:: {
@@ -367,8 +367,8 @@
         ingestion_burst_size: 15000000,  // 15M
 
         // 900 rules
-        max_rules_per_rule_group: 15,
-        max_rule_groups_per_tenant: 60,
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 60,
       },
 
       // This user class has limits increased by +50% compared to the previous one.
@@ -386,8 +386,8 @@
         ingestion_burst_size: 22500000,  // 22.5M
 
         // 1050 rules
-        max_rules_per_rule_group: 15,
-        max_rule_groups_per_tenant: 70,
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 70,
       },
     },
 

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -20,8 +20,8 @@
       'ruler.ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
 
       // Limits
-      'ruler.max-rules-per-rule-group': $._config.limits.max_rules_per_rule_group,
-      'ruler.max-rule-groups-per-tenant': $._config.limits.max_rule_groups_per_tenant,
+      'ruler.max-rules-per-rule-group': $._config.limits.ruler_max_rules_per_rule_group,
+      'ruler.max-rule-groups-per-tenant': $._config.limits.ruler_max_rule_groups_per_tenant,
     },
 
   ruler_container::


### PR DESCRIPTION
**What this PR does**:

Ruler limits have a prefix of `ruler_` on the config key name. This
makes the key match and then uses them as the value for the flags.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
