### PR TITLE
Improve blocks storage observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 * [ENHANCEMENT] Introduce a resources dashboard for the Alertmanager. #219
 * [ENHANCEMENT] Improves query visibility in the Ruler Dashboard for both chunks and blocks storage. #226
 * [ENHANCEMENT] Add query-scheduler to dashboards. Add alert for queries stuck in scheduler. #228
+* [ENHANCEMENT] Improved blocks storage observability: #224
+  - Cortex / Writes: added current number of tenants in the cluster
+  - Cortex / Writes Resources: added ingester disk read/writes/utilisation
+  - Cortex / Reads Resources: added store-gateway disk read/writes/utilisation
+  - Cortex / Queries: added "Lazy loaded index-headers" and "Index-header lazy load duration"
+  - Cortex / Compactor: added "Tenants compaction progress"
+  - Alerts: added "CortexMemoryMapAreasTooHigh"
 
 ## 1.5.0 / 2020-11-12
 

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -242,7 +242,7 @@
         {
           alert: 'CortexMemoryMapAreasTooHigh',
           expr: |||
-            process_memory_map_areas{job=~".+(cortex|ingester)"} / process_memory_map_areas_limit{job=~".+(cortex|ingester)"} > 0.8
+            process_memory_map_areas{job=~".+(cortex|ingester|store-gateway)"} / process_memory_map_areas_limit{job=~".+(cortex|ingester|store-gateway)"} > 0.8
           |||,
           'for': '5m',
           labels: {

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -239,6 +239,19 @@
             |||,
           },
         },
+        {
+          alert: 'CortexMemoryMapAreasTooHigh',
+          expr: |||
+            process_memory_map_areas{job=~".+(cortex|ingester)"} / process_memory_map_areas_limit{job=~".+(cortex|ingester)"} > 0.8
+          |||,
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '{{ $labels.job }}/{{ $labels.instance }} has a number of mmap-ed areas close to the limit.',
+          },
+        },
       ],
     },
     {

--- a/cortex-mixin/dashboards/compactor-resources.libsonnet
+++ b/cortex-mixin/dashboards/compactor-resources.libsonnet
@@ -2,10 +2,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
   'cortex-compactor-resources.json':
-    local filterNodeDiskByCompactor = |||
-      ignoring(pod) group_right() (label_replace(count by(pod, instance, device) (container_fs_writes_bytes_total{%s,container="compactor",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
-    ||| % $.namespaceMatcher();
-
     ($.dashboard('Cortex / Compactor Resources') + { uid: 'df9added6f1f4332f95848cca48ebd99' })
     .addClusterSelectorTemplates()
     .addRow(
@@ -38,20 +34,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Disk')
       .addPanel(
-        $.panel('Writes') +
-        $.queryPanel('sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % filterNodeDiskByCompactor, '{{pod}} - {{device}}') +
+        $.panel('Disk Writes') +
+        $.queryPanel('sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % $.filterNodeDiskContainer('compactor'), '{{pod}} - {{device}}') +
         $.stack +
         { yaxes: $.yaxes('Bps') },
       )
       .addPanel(
-        $.panel('Reads') +
-        $.queryPanel('sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % filterNodeDiskByCompactor, '{{pod}} - {{device}}') +
+        $.panel('Disk Reads') +
+        $.queryPanel('sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % $.filterNodeDiskContainer('compactor'), '{{pod}} - {{device}}') +
         $.stack +
         { yaxes: $.yaxes('Bps') },
       )
-    )
-    .addRow(
-      $.row('')
       .addPanel(
         $.panel('Disk Space Utilization') +
         $.queryPanel('max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{%s} / kubelet_volume_stats_capacity_bytes{%s}) and count by(persistentvolumeclaim) (kube_persistentvolumeclaim_labels{%s,label_name="compactor"})' % [$.namespaceMatcher(), $.namespaceMatcher(), $.namespaceMatcher()], '{{persistentvolumeclaim}}') +

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -9,8 +9,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.textPanel('', |||
           - **Per-instance runs**: number of times a compactor instance triggers a compaction across all tenants its shard manage.
-          - **Compacted blocks**: number of blocks generated as a result of a compaction operation.
-          - **Per-block compaction duration**: time taken to generate a single compacted block.
+          - **Tenants compaction progress**: in a multi-tenant cluster it shows the progress of tenants compacted while compaction is running. Reset to 0 once the compaction run is completed for all tenants in the shard.
         |||),
       )
       .addPanel(
@@ -22,6 +21,26 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ) +
         $.bars +
         { yaxes: $.yaxes('ops') },
+      )
+      .addPanel(
+        $.panel('Tenants compaction progress') +
+        $.queryPanel(|||
+          (
+            cortex_compactor_tenants_processing_succeeded{%s} +
+            cortex_compactor_tenants_processing_failed{%s} +
+            cortex_compactor_tenants_skipped{%s}
+          ) / cortex_compactor_tenants_discovered{%s}
+        ||| % [$.jobMatcher('compactor'), $.jobMatcher('compactor'), $.jobMatcher('compactor'), $.jobMatcher('compactor')], '{{instance}}') +
+        { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.textPanel('', |||
+          - **Compacted blocks**: number of blocks generated as a result of a compaction operation.
+          - **Per-block compaction duration**: time taken to generate a single compacted block.
+        |||),
       )
       .addPanel(
         $.panel('Compacted blocks / sec') +

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -239,4 +239,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { yaxes: $.yaxes('percentunit') },
     ),
 
+
+  filterNodeDiskContainer(containerName)::
+    |||
+      ignoring(pod) group_right() (label_replace(count by(pod, instance, device) (container_fs_writes_bytes_total{%s,container="%s",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
+    ||| % [$.namespaceMatcher(), containerName],
 }

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -212,5 +212,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'sum(rate(cortex_bucket_store_block_drop_failures_total{component="store-gateway",%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.store_gateway),
         )
       )
+    )
+    .addRowIf(
+      std.member($._config.storage_engine, 'blocks'),
+      $.row('')
+      .addPanel(
+        $.panel('Lazy loaded index-headers') +
+        $.queryPanel('cortex_bucket_store_indexheader_lazy_load_total{%s} - cortex_bucket_store_indexheader_lazy_unload_total{%s}' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)], '{{instance}}')
+      )
+      .addPanel(
+        $.panel('Index-header lazy load duration') +
+        $.latencyPanel('cortex_bucket_store_indexheader_lazy_load_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.store_gateway)),
+      )
     ),
 }

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -95,6 +95,27 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.goHeapInUsePanel('Memory (go heap inuse)', 'store-gateway'),
       )
+    )
+    .addRowIf(
+      std.member($._config.storage_engine, 'blocks'),
+      $.row('')
+      .addPanel(
+        $.panel('Disk Writes') +
+        $.queryPanel('sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % $.filterNodeDiskContainer('store-gateway'), '{{pod}} - {{device}}') +
+        $.stack +
+        { yaxes: $.yaxes('Bps') },
+      )
+      .addPanel(
+        $.panel('Disk Reads') +
+        $.queryPanel('sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % $.filterNodeDiskContainer('store-gateway'), '{{pod}} - {{device}}') +
+        $.stack +
+        { yaxes: $.yaxes('Bps') },
+      )
+      .addPanel(
+        $.panel('Disk Space Utilization') +
+        $.queryPanel('max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{%s} / kubelet_volume_stats_capacity_bytes{%s}) and count by(persistentvolumeclaim) (kube_persistentvolumeclaim_labels{%s,label_name="store-gateway"})' % [$.namespaceMatcher(), $.namespaceMatcher(), $.namespaceMatcher()], '{{persistentvolumeclaim}}') +
+        { yaxes: $.yaxes('percentunit') },
+      )
     ) + {
       templating+: {
         list: [

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -47,6 +47,26 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
       )
     )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.panel('Disk Writes') +
+        $.queryPanel('sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % $.filterNodeDiskContainer('ingester'), '{{pod}} - {{device}}') +
+        $.stack +
+        { yaxes: $.yaxes('Bps') },
+      )
+      .addPanel(
+        $.panel('Disk Reads') +
+        $.queryPanel('sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % $.filterNodeDiskContainer('ingester'), '{{pod}} - {{device}}') +
+        $.stack +
+        { yaxes: $.yaxes('Bps') },
+      )
+      .addPanel(
+        $.panel('Disk Space Utilization') +
+        $.queryPanel('max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{%s} / kubelet_volume_stats_capacity_bytes{%s}) and count by(persistentvolumeclaim) (kube_persistentvolumeclaim_labels{%s,label_name="ingester"})' % [$.namespaceMatcher(), $.namespaceMatcher(), $.namespaceMatcher()], '{{persistentvolumeclaim}}') +
+        { yaxes: $.yaxes('percentunit') },
+      )
+    )
     + {
       templating+: {
         list: [

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -26,6 +26,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         }, format='short')
       )
       .addPanel(
+        $.panel('Tenants') +
+        $.statPanel('count(count by(user) (cortex_ingester_active_series{%s}))' % $.jobMatcher($._config.job_names.ingester), format='short')
+      )
+      .addPanel(
         $.panel('QPS') +
         $.statPanel('sum(rate(cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}[5m]))' % $.jobMatcher($._config.job_names.gateway), format='reqps')
       )

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -53,26 +53,17 @@ This alert goes off when an ingester fails to find another node to transfer its 
 ### CortexIngesterUnhealthy
 This alert goes off when an ingester is marked as unhealthy. Check the ring web page to see which is marked as unhealthy. You could then check the logs to see if there are any related to that ingester ex: `kubectl logs -f ingester-01 --namespace=prod`. A simple way to resolve this may be to click the "Forgot" button on the ring page, especially if the pod doesn't exist anymore. It might not exist anymore because it was on a node that got shut down, so you could check to see if there are any logs related to the node that pod is/was on, ex: `kubectl get events --namespace=prod | grep cloud-provider-node`.
 
-### CortexFlushStuck
-@todo
+### CortexMemoryMapAreasTooHigh
 
-### CortexLoadBalancerErrors
-@todo
+This alert fires when a Cortex process has a number of memory map areas close to the limit. The limit is a per-process limit imposed by the kernel and this issue is typically caused by a large number of mmap-ed failes.
 
-### CortexTableSyncFailure
-@todo
+How to **fix**:
+- Increase the limit on your system: `sysctl -w vm.max_map_count=<NEW LIMIT>`
+- If it's caused by a store-gateway, consider enabling `-blocks-storage.bucket-store.index-header-lazy-loading-enabled=true` to lazy mmap index-headers at query time
 
-### CortexQuerierCapacityFull
-@todo
-
-### CortexFrontendQueriesStuck
-@todo
-
-### CortexProvisioningTooMuchMemory
-@todo
-
-### MemcachedDown
-@todo
+More information:
+- [Kernel doc](https://www.kernel.org/doc/Documentation/sysctl/vm.txt)
+- [Side effects when increasing `vm.max_map_count`](https://www.suse.com/support/kb/doc/?id=000016692)
 
 ### CortexRulerFailedRingCheck
 


### PR DESCRIPTION
**What this PR does**:
In this PR I've introduced new panels and an alert related to the blocks storage, to improve the visibility we have over all operational aspects:

- Cortex / Writes
  - Headlines: added current number of tenants in the cluster
- Cortex / Writes Resources
  - Added ingester disk read/writes/utilisation
- Cortex / Reads Resources
  - Added store-gateway disk read/writes/utilisation
- Cortex / Queries
  - Added "Lazy loaded index-headers"
  - Added "Lazy load duration"
- Cortex / Compactor
  - Added "Tenants compaction progress"
- Alerts
  - CortexMemoryMapAreasTooHigh

_I manually tested the dashboards and should work as expected._

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
