### PR TITLE
Add query-scheduler to dashboards and alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Add default present for ruler limits on all 'user' types. #221, #222
 * [CHANGE] Enabled sharding for the blocks storage compactor. #218
 * [ENHANCEMENT] Introduce a resources dashboard for the Alertmanager. #219
+* [ENHANCEMENT] Add query-scheduler to dashboards. Add alert for queries stuck in scheduler. #228
 
 ## 1.5.0 / 2020-11-12
 

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -157,7 +157,22 @@
           },
           annotations: {
             message: |||
-              There are {{ $value }} queued up queries.
+              There are {{ $value }} queued up queries in query-frontend.
+            |||,
+          },
+        },
+        {
+          alert: 'CortexSchedulerQueriesStuck',
+          expr: |||
+            sum by (%s) (cortex_query_scheduler_queue_length) > 1
+          ||| % $._config.alert_aggregation_labels,
+          'for': '5m',  // We don't want to block for longer.
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: |||
+              There are {{ $value }} queued up queries in query-scheduler.
             |||,
           },
         },

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -31,6 +31,7 @@
       querier: '(querier|cortex$)',
       ruler: '(ruler|cortex$)',
       query_frontend: '(query-frontend|cortex$)',
+      query_scheduler: 'query-scheduler',  // Not part of single-binary.
       table_manager: '(table-manager|cortex$)',
       store_gateway: '(store-gateway|cortex$)',
       gateway: 'cortex-gw',

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -22,6 +22,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
+      $.row('Query Scheduler')
+      .addPanel(
+        $.panel('Queue Duration') +
+        $.latencyPanel('cortex_query_scheduler_queue_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.query_scheduler)),
+      )
+      .addPanel(
+        $.panel('Queue Length') +
+        $.queryPanel('cortex_query_scheduler_queue_length{%s}' % $.jobMatcher($._config.job_names.query_scheduler), '{{cluster}} / {{namespace}} / {{instance}}'),
+      )
+    )
+    .addRow(
       $.row('Query Frontend - Results Cache')
       .addPanel(
         $.panel('Cache Hit %') +

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -29,6 +29,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
+      $.row('Query Scheduler')
+      .addPanel(
+        $.containerCPUUsagePanel('CPU', 'query-scheduler'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
+      )
+      .addPanel(
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-scheduler'),
+      )
+    )
+    .addRow(
       $.row('Querier')
       .addPanel(
         $.containerCPUUsagePanel('CPU', 'querier'),

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -41,6 +41,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
+      $.row('Query Scheduler')
+      .addPanel(
+        $.panel('QPS') +
+        $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
+      )
+      .addPanel(
+        $.panel('Latency (Time in Queue)') +
+        $.latencyPanel('cortex_query_scheduler_queue_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
+      )
+    )
+    .addRow(
       $.row('Cache - Query Results')
       .addPanel(
         $.panel('QPS') +


### PR DESCRIPTION
**What this PR does**: This PR adds query-scheduler to dashboards (Reads, Reads Resources and Queries), and adds single alert for stuck queries in scheduler (`CortexSchedulerQueriesStuck`).

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
