### PR TITLE
Fixed workingset memory panel while rolling out a StatefulSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Cortex / Queries: added "Lazy loaded index-headers" and "Index-header lazy load duration"
   - Cortex / Compactor: added "Tenants compaction progress"
   - Alerts: added "CortexMemoryMapAreasTooHigh"
+* [BUGFIX] Fixed workingset memory panel while rolling out a StatefulSet. #229
 
 ## 1.5.0 / 2020-11-12
 

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -136,7 +136,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerMemoryWorkingSetPanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([
-      'sum by(pod) (container_memory_working_set_bytes{%s,container="%s"})' % [$.namespaceMatcher(), containerName],
+      // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
+      // summing the memory of the old pod (whose metric will be stale for 5m) to the new pod.
+      'max by(pod) (container_memory_working_set_bytes{%s,container="%s"})' % [$.namespaceMatcher(), containerName],
       'min(container_spec_memory_limit_bytes{%s,container="%s"} > 0)' % [$.namespaceMatcher(), containerName],
     ], ['{{pod}}', 'limit']) +
     {


### PR DESCRIPTION
**What this PR does**:
Everytime we rollout ingesters, I see this worrying trend:
![Screenshot 2020-12-14 at 10 01 26](https://user-images.githubusercontent.com/1701904/102061304-9620a080-3df3-11eb-97aa-8d092b43e6d0.png)

Today I've investigated it and it turned out to be a false positive. The problem is that during the rollout of a statefulset we have duplicated series, both the old pod and the new pod (even if the pod ID is the same, the metric have other labels which are distinct).

In the following panel, on the left you can see `sum by(pod)` while on the right you can see the 2 series:
![Screenshot 2020-12-14 at 10 01 37](https://user-images.githubusercontent.com/1701904/102061381-b51f3280-3df3-11eb-9d2a-80c319ab3972.png)

This PR should fix it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
