### PR TITLE
Removed postings-compression-enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Add default present for ruler limits on all 'user' types. #221, #222
 * [CHANGE] Enabled sharding for the blocks storage compactor. #218
+* [CHANGE] Removed `-blocks-storage.bucket-store.index-cache.postings-compression-enabled` CLI flag because always enabled in Cortex 1.6. #224
 * [ENHANCEMENT] Introduce a resources dashboard for the Alertmanager. #219
 * [ENHANCEMENT] Improves query visibility in the Ruler Dashboard for both chunks and blocks storage. #226
 * [ENHANCEMENT] Add query-scheduler to dashboards. Add alert for queries stuck in scheduler. #228

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -36,7 +36,6 @@
         'blocks-storage.bucket-store.index-cache.memcached.max-async-buffer-size': '25000',
         'blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency': '50',
         'blocks-storage.bucket-store.index-cache.memcached.max-get-multi-batch-size': '100',
-        'blocks-storage.bucket-store.index-cache.postings-compression-enabled': 'true',
       } else {}
     ) + (
       if $._config.memcached_chunks_enabled then {


### PR DESCRIPTION
**What this PR does**:
The flag `-blocks-storage.bucket-store.index-cache.postings-compression-enabled` has been deprecated and is unused in Cortex `master` / 1.6, because the postings compression is always enabled (support to conditionally disable it has been removed from Thanos).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
