### PR TITLE
Add option to configure unregister ingesters on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
+
 ## 1.6.0 / 2021-01-05
 
 * [CHANGE] Add default present for ruler limits on all 'user' types. #221, #222
@@ -20,7 +22,6 @@
 * [ENHANCEMENT] Fine-tuned gRPC keepalive pings to work nicely with Cortex default settings. #233 #234
   - `-server.grpc.keepalive.min-time-between-pings=10s`
   - `-server.grpc.keepalive.ping-without-stream-allowed:true`
-* [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
 * [BUGFIX] Fixed workingset memory panel while rolling out a StatefulSet. #229
 * [BUGFIX] Fixed `CortexRequestErrors` alert to not include `ready` route. #230
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Fine-tuned gRPC keepalive pings to work nicely with Cortex default settings. #233 #234
   - `-server.grpc.keepalive.min-time-between-pings=10s`
   - `-server.grpc.keepalive.ping-without-stream-allowed:true`
+* [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
 * [BUGFIX] Fixed workingset memory panel while rolling out a StatefulSet. #229
 * [BUGFIX] Fixed `CortexRequestErrors` alert to not include `ready` route. #230
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -15,8 +15,9 @@
 
     // If false, ingesters are not unregistered on shutdown and left in the ring with
     // the LEAVING state. Setting to false prevents series resharding during ingesters rollouts,
-    // but requires to manually forget ingesters on scale down and that ingester ID is preserved
-    // during rollouts.
+    // but requires to:
+    // 1. Either manually forget ingesters on scale down or invoke the /shutdown endpoint
+    // 2. Ensure ingester ID is preserved during rollouts
     unregister_ingesters_on_shutdown: true,
 
     // schema is used to generate the storage schema yaml file used by

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -13,8 +13,8 @@
     aws_region: error 'must specify AWS region',
     s3_bucket_name: error 'must specify S3 bucket name',
 
-    // If disabled, ingesters are not unregistered on shutdown and left in the ring with
-    // the LEAVING state. Disabling it prevents series resharding during ingesters rollouts,
+    // If false, ingesters are not unregistered on shutdown and left in the ring with
+    // the LEAVING state. Setting to false prevents series resharding during ingesters rollouts,
     // but requires to manually forget ingesters on scale down and that ingester ID is preserved
     // during rollouts.
     unregister_ingesters_on_shutdown: true,

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -13,6 +13,12 @@
     aws_region: error 'must specify AWS region',
     s3_bucket_name: error 'must specify S3 bucket name',
 
+    // If disabled, ingesters are not unregistered on shutdown and left in the ring with
+    // the LEAVING state. Disabling it prevents series resharding during ingesters rollouts,
+    // but requires to manually forget ingesters on scale down and that ingester ID is preserved
+    // during rollouts.
+    unregister_ingesters_on_shutdown: true,
+
     // schema is used to generate the storage schema yaml file used by
     // the Cortex chunks storage:
     // - More information: https://github.com/cortexproject/cortex/pull/1072

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -37,8 +37,8 @@
       'distributor.ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
       'distributor.ring.prefix': '',
 
-      // Do not extend the replication set on unhealthy ingester when "unregister on shutdown"
-      // is disabled.
+      // Do not extend the replication set on unhealthy (or LEAVING) ingester when "unregister on shutdown"
+      // is set to false.
       'distributor.extend-writes': $._config.unregister_ingesters_on_shutdown,
     ),
 

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -36,12 +36,10 @@
       // The ingestion rate global limit requires the distributors to form a ring.
       'distributor.ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
       'distributor.ring.prefix': '',
-    } + (
-      if !$._config.unregister_ingesters_on_shutdown then
-        {
-          'distributor.extend-writes': false,
-        }
-      else {}
+
+      // Do not extend the replication set on unhealthy ingester when "unregister on shutdown"
+      // is disabled.
+      'distributor.extend-writes': $._config.unregister_ingesters_on_shutdown,
     ),
 
   distributor_ports:: $.util.defaultPorts,

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -36,7 +36,13 @@
       // The ingestion rate global limit requires the distributors to form a ring.
       'distributor.ring.consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
       'distributor.ring.prefix': '',
-    },
+    } + (
+      if !$._config.unregister_ingesters_on_shutdown then
+        {
+          'distributor.extend-writes': false,
+        }
+      else {}
+    ),
 
   distributor_ports:: $.util.defaultPorts,
 

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -15,6 +15,7 @@
       'ingester.max-transfer-retries': 60,  // Each retry is backed off by 5s, so 5mins for new ingester to come up.
       'ingester.heartbeat-period': '15s',
       'ingester.max-stale-chunk-idle': '5m',
+      'ingester.unregister-on-shutdown': $._config.unregister_ingesters_on_shutdown,
 
       // Chunk building/flushing config.
       'ingester.chunk-encoding': 3,  // Bigchunk encoding
@@ -37,12 +38,6 @@
           // Setup index write deduping.
           'store.index-cache-write.memcached.hostname': 'memcached-index-writes.%(namespace)s.svc.cluster.local' % $._config,
           'store.index-cache-write.memcached.service': 'memcached-client',
-        }
-      else {}
-    ) + (
-      if !$._config.unregister_ingesters_on_shutdown then
-        {
-          'ingester.unregister-on-shutdown': false,
         }
       else {}
     ),

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -39,6 +39,12 @@
           'store.index-cache-write.memcached.service': 'memcached-client',
         }
       else {}
+    ) + (
+      if !$._config.unregister_ingesters_on_shutdown then
+        {
+          'ingester.unregister-on-shutdown': false,
+        }
+      else {}
     ),
 
   ingester_statefulset_args::

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -27,7 +27,13 @@
       'querier.second-store-engine': $._config.querier_second_storage_engine,
 
       'log.level': 'debug',
-    },
+    } + (
+      if !$._config.unregister_ingesters_on_shutdown then
+        {
+          'distributor.extend-writes': false,
+        }
+      else {}
+    ),
 
   querier_ports:: $.util.defaultPorts,
 

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -27,13 +27,7 @@
       'querier.second-store-engine': $._config.querier_second_storage_engine,
 
       'log.level': 'debug',
-    } + (
-      if !$._config.unregister_ingesters_on_shutdown then
-        {
-          'distributor.extend-writes': false,
-        }
-      else {}
-    ),
+    },
 
   querier_ports:: $.util.defaultPorts,
 


### PR DESCRIPTION
**What this PR does**:
In this PR I've added an option to allow to configure the "unregister ingesters on shutdown" (enabled by default). The CLI flags are added conditionally in order to avoid any config change unless you disable the unregistering.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
