### PR TITLE
Remove misleading comment

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -287,8 +287,7 @@
 
     // === Per-tenant usage limits. ===
     //
-    // These are the defaults. Distributor limits will be 5x (#replicas) higher,
-    // ingester limits are 6s (#replicas) / 3x (#replication factor) higher.
+    // These are the defaults.
     limits: $._config.overrides.extra_small_user,
 
     overrides: {


### PR DESCRIPTION
**What this PR does**:
I found a misleading comment in the limits config. I think this comes from the very past.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
