### PR TITLE
Honor configured job_names in the 'Memory (go heap inuse)' panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] The name of the overrides configmap is now customisable via `$._config.overrides_configmap`. #244
 * [BUGFIX] Honor configured `per_instance_label` in all panels. #239
 * [BUGFIX] `CortexRequestLatency` alert now ignores long-running requests on query-scheduler. #242
+* [BUGFIX] Honor configured `job_names` in the "Memory (go heap inuse)" panel. #247
 
 ## 1.6.0 / 2021-01-05
 

--- a/cortex-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager-resources.libsonnet
@@ -13,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
       )
     )
     .addRow(

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -13,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
       )
     )
     .addRow(
@@ -25,7 +25,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-frontend'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.query_frontend),
       )
     )
     .addRow(
@@ -37,7 +37,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-scheduler'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.query_scheduler),
       )
     )
     .addRow(
@@ -49,7 +49,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'querier'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.querier),
       )
     )
     .addRow(
@@ -61,7 +61,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ingester'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ingester),
       )
     )
     .addRow(
@@ -83,7 +83,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ruler),
       )
     )
     .addRowIf(
@@ -96,7 +96,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'store-gateway'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'store-gateway'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.store_gateway),
       )
     )
     .addRowIf(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -143,7 +143,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.row('Memcached – Blocks Storage – Index header (Store-gateway)')
+      $.row('Memcached – Blocks Storage – Block Index (Store-gateway)')
       .addPanel(
         $.panel('QPS') +
         $.queryPanel('sum by(operation) (rate(thanos_memcached_operations_total{component="store-gateway",name="index-cache", %s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.store_gateway), '{{operation}}') +

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -13,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),
       )
     )
     .addRow(
@@ -25,7 +25,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'distributor'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'distributor'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.distributor),
       )
     )
     .addRow(
@@ -47,7 +47,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ingester'),
       )
       .addPanel(
-        $.goHeapInUsePanel('Memory (go heap inuse)', 'ingester'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ingester),
       )
     )
     .addRow(


### PR DESCRIPTION
**What this PR does**:
Today I realised the configure `job_names` is not honored in the 'Memory (go heap inuse)' panel. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
