### PR TITLE
Disable multi-selection for variables in resources dashboards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master / unreleased
 
+* [CHANGE] Only single cluster and namespace can now be selected in "resources" dashboards. #251
 * [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
 * [ENHANCEMENT] Improved blocks storage observability: #237
   - Cortex / Queries: added bucket index load operations and latency (available only when bucket index is enabled)

--- a/cortex-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager-resources.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
   'alertmanager-resources.json':
     ($.dashboard('Cortex / Alertmanager Resources') + { uid: '68b66aed90ccab448009089544a8d6c6' })
-    .addClusterSelectorTemplates()
+    .addClusterSelectorTemplates(false)
     .addRow(
       $.row('Gateway')
       .addPanel(

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -14,7 +14,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         then self.addRow(row)
         else self,
 
-      addClusterSelectorTemplates()::
+      addClusterSelectorTemplates(multi=true)::
         local d = self {
           tags: $._config.tags,
           links: [
@@ -31,11 +31,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ],
         };
 
-        if $._config.singleBinary
-        then d.addMultiTemplate('job', 'cortex_build_info', 'job')
-        else d
-             .addMultiTemplate('cluster', 'cortex_build_info', 'cluster')
-             .addMultiTemplate('namespace', 'cortex_build_info', 'namespace'),
+        if multi then
+          if $._config.singleBinary
+          then d.addMultiTemplate('job', 'cortex_build_info', 'job')
+          else d
+               .addMultiTemplate('cluster', 'cortex_build_info', 'cluster')
+               .addMultiTemplate('namespace', 'cortex_build_info', 'namespace')
+        else
+          if $._config.singleBinary
+          then d.addTemplate('job', 'cortex_build_info', 'job')
+          else d
+               .addTemplate('cluster', 'cortex_build_info', 'cluster')
+               .addTemplate('namespace', 'cortex_build_info', 'namespace'),
+
     },
 
   // The mixin allow specialism of the job selector depending on if its a single binary

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
   'cortex-reads-resources.json':
     ($.dashboard('Cortex / Reads Resources') + { uid: '2fd2cda9eea8d8af9fbc0a5960425120' })
-    .addClusterSelectorTemplates()
+    .addClusterSelectorTemplates(false)
     .addRow(
       $.row('Gateway')
       .addPanel(

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -3,7 +3,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 (import 'dashboard-utils.libsonnet') {
   'cortex-writes-resources.json':
     ($.dashboard('Cortex / Writes Resources') + { uid: 'c0464f0d8bd026f776c9006b0591bb0b' })
-    .addClusterSelectorTemplates()
+    .addClusterSelectorTemplates(false)
     .addRow(
       $.row('Gateway')
       .addPanel(


### PR DESCRIPTION
**What this PR does**: This PR disables multi-selection of `cluster` and `namespace` variable in resources dashboards.

I think we should do it in all dashboards, but this conservative PR is a first step to see what others think about it.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
