### PR TITLE
Fix -querier.second-store-engine in the ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [BUGFIX] Honor configured `job_names` in the "Memory (go heap inuse)" panel. #247
 * [BUGFIX] Fixed ingester "Disk Space Utilization" to include any `ingester.*` PV. #249
 * [BUGFIX] Fixed ingester alerts to include any `ingester.*` job. #252
+* [BUGFIX] Set `-querier.second-store-engine` in the ruler too when `querier_second_storage_engine` is configured. #253
 
 ## 1.6.0 / 2021-01-05
 

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -23,6 +23,9 @@
       // Limits
       'ruler.max-rules-per-rule-group': $._config.limits.ruler_max_rules_per_rule_group,
       'ruler.max-rule-groups-per-tenant': $._config.limits.ruler_max_rule_groups_per_tenant,
+
+      // Storage
+      'querier.second-store-engine': $._config.querier_second_storage_engine,
     },
 
   ruler_container::


### PR DESCRIPTION
**What this PR does**:
The ruler internally runs the querier, so any querier config option applies to ruler too. I just realised that, when `querier_second_storage_engine` is configured, we're not setting `-querier.second-store-engine` in the ruler too. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
