### PR TITLE
Increased CortexAllocatingTooMuchMemory alert threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] Only single cluster and namespace can now be selected in "resources" dashboards. #251
+* [CHANGE] Increased `CortexAllocatingTooMuchMemory` warning alert threshold from 50% to 65%. #256
 * [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
 * [ENHANCEMENT] Improved blocks storage observability: #237
   - Cortex / Queries: added bucket index load operations and latency (available only when bucket index is enabled)

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -404,7 +404,7 @@
               container_memory_working_set_bytes{container="ingester"}
                 /
               container_spec_memory_limit_bytes{container="ingester"}
-            ) > 0.5
+            ) > 0.65
           |||,
           'for': '15m',
           labels: {


### PR DESCRIPTION
**What this PR does**:
The `CortexAllocatingTooMuchMemory` **warning** alert is triggering continuously in our clusters, to the point it became useless. I believe a 50% threshold is too low (not realistic) so I would suggest to increase it to 65%.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
