### PR TITLE
Cleanup blocks storage config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Only single cluster and namespace can now be selected in "resources" dashboards. #251
 * [CHANGE] Increased `CortexAllocatingTooMuchMemory` warning alert threshold from 50% to 65%. #256
+* [CHANGE] Cleaned up blocks storage config. Moved CLI flags used only be the read path from `genericBlocksStorageConfig` to `queryBlocksStorageConfig`, and flags used only by the ingester from `genericBlocksStorageConfig` to `ingester_args`. #257
 * [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
 * [ENHANCEMENT] Improved blocks storage observability: #237
   - Cortex / Queries: added bucket index load operations and latency (available only when bucket index is enabled)

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -159,12 +159,10 @@
 
     genericBlocksStorageConfig:: {
       'store.engine': $._config.storage_engine,  // May still be chunks
-      'blocks-storage.tsdb.dir': '/data/tsdb',
+    },
+    queryBlocksStorageConfig:: {
       'blocks-storage.bucket-store.sync-dir': '/data/tsdb',
       'blocks-storage.bucket-store.ignore-deletion-marks-delay': '1h',
-      'blocks-storage.tsdb.block-ranges-period': '2h',
-      'blocks-storage.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
-      'blocks-storage.tsdb.ship-interval': '1m',
 
       'store-gateway.sharding-enabled': true,
       'store-gateway.sharding-ring.store': 'consul',

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -72,8 +72,8 @@
     'blocks-storage.bucket-store.sync-interval': $._config.cortex_compactor_cleanup_interval,
   } else {},
 
-  querier_args+:: $.blocks_metadata_caching_config + $.bucket_index_config,
-  ruler_args+:: $.blocks_metadata_caching_config + $.bucket_index_config,
+  querier_args+:: $._config.queryBlocksStorageConfig + $.blocks_metadata_caching_config + $.bucket_index_config,
+  ruler_args+:: $._config.queryBlocksStorageConfig + $.blocks_metadata_caching_config + $.bucket_index_config,
 
   // The ingesters should persist TSDB blocks and WAL on a persistent
   // volume in order to be crash resilient.
@@ -87,6 +87,11 @@
   ingester_deployment: {},
 
   ingester_args+:: {
+    'blocks-storage.tsdb.dir': '/data/tsdb',
+    'blocks-storage.tsdb.block-ranges-period': '2h',
+    'blocks-storage.tsdb.retention-period': '96h',  // 4 days protection against blocks not being uploaded from ingesters.
+    'blocks-storage.tsdb.ship-interval': '1m',
+
     // Disable TSDB blocks transfer because of persistent volumes
     'ingester.max-transfer-retries': 0,
     'ingester.join-after': '0s',
@@ -196,6 +201,7 @@
     $._config.grpcConfig +
     $._config.storageConfig +
     $._config.blocksStorageConfig +
+    $._config.queryBlocksStorageConfig +
     {
       target: 'store-gateway',
       'limits.per-user-override-config': '/etc/cortex/overrides.yaml',


### PR DESCRIPTION
**What this PR does**:
When we introduced the blocks store support to jsonnet we picked the easiest path: define a `genericBlocksStorageConfig` and set all CLI flags there. These flags were applied to all Cortex services accessing the  storage (ingester, querier, ruler, store-gateway, compactor).

However, not all flags we set in `genericBlocksStorageConfig` are used by all Cortex services. For example, the flag with prefix `-blocks-storage.tsdb.` are ingester specific.

In this PR I'm cleaning up the config, setting each CLI flag (related to blocks storage) only to Cortex services that actually use it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
