### PR TITLE
feat: allow for Alertmanager to configure multiple storage backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## master / unreleased
 
+* [CHANGE] Alertmanager storage backend no longer defaults to `gcs` with bucket name `'%(cluster)s-cortex-%(namespace)s' % $._config`. #258
 * [CHANGE] Only single cluster and namespace can now be selected in "resources" dashboards. #251
 * [CHANGE] Increased `CortexAllocatingTooMuchMemory` warning alert threshold from 50% to 65%. #256
 * [CHANGE] Cleaned up blocks storage config. Moved CLI flags used only be the read path from `genericBlocksStorageConfig` to `queryBlocksStorageConfig`, and flags used only by the ingester from `genericBlocksStorageConfig` to `ingester_args`. #257
+* [ENHANCEMENT] Add dedicated parameters to `_config` to configure Alertmanager backend storage. #258
+  * `alertmanager_client_type`
+  * `alertmanager_s3_bucket_name`
+  * `alertmanager_gcs_bucket_name`
 * [ENHANCEMENT] Added `unregister_ingesters_on_shutdown` config option to disable unregistering ingesters on shutdown (default is enabled). #213
 * [ENHANCEMENT] Improved blocks storage observability: #237
   - Cortex / Queries: added bucket index load operations and latency (available only when bucket index is enabled)

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -18,7 +18,7 @@
 
   alertmanager_args::
     $._config.grpcConfig +
-    $._config.alertmanagerClientConfig +
+    $._config. alertmanagerStorageClientConfig +
     {
       target: 'alertmanager',
       'log.level': 'debug',

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -18,14 +18,12 @@
 
   alertmanager_args::
     $._config.grpcConfig +
+    $._config.alertmanagerClientConfig +
     {
       target: 'alertmanager',
       'log.level': 'debug',
-
       'experimental.alertmanager.enable-api': 'true',
-      'alertmanager.storage.type': 'gcs',
       'alertmanager.storage.path': '/data',
-      'alertmanager.storage.gcs.bucketname': '%(cluster)s-cortex-%(namespace)s' % $._config,
       'alertmanager.web.external-url': '%s/alertmanager' % $._config.external_url,
     } + if hasFallbackConfig then {
       'alertmanager.configs.fallback': '/configs/alertmanager_fallback_config.yaml',

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -287,7 +287,7 @@
     alertmanager_s3_bucket_name: $._config.s3_bucket_name,
     alertmanager_gcs_bucket_name: error 'must specify a GCS bucket name',
 
-    alertmanagerClientConfig:
+    alertmanagerStorageClientConfig:
       {
         'alertmanager.storage.type': $._config.alertmanager_client_type,
       } +

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -283,6 +283,29 @@
       fallback_config: {},
     },
 
+    alertmanager_client_type: error 'you must specify a storage backend type for the ruler (azure, configdb, gcs, s3, local)',
+    alertmanager_s3_bucket_name: $._config.s3_bucket_name,
+    alertmanager_gcs_bucket_name: error 'must specify a GCS bucket name',
+
+    alertmanagerClientConfig:
+      {
+        'alertmanager.storage.type': $._config.alertmanager_client_type,
+      } +
+      {
+        configdb: {
+          configs_api_url: 'config.%s.svc.cluster.local' % $._config.namespace,
+        },
+        gcs: {
+          'alertmanager.storage.gcs.bucketname': $._config.alertmanager_gcs_bucket_name,
+        },
+        s3: {
+          'alertmanager.storage.s3.url': 'https://%s/%s' % [$._config.aws_region, $._config.alertmanager_s3_bucket_name],
+        },
+        'local': {
+          'alertmanager.storage.local.directory': $._config.alertmanager_local_directory,
+        },
+      }[$._config.alertmanager_client_type],
+
     // === Per-tenant usage limits. ===
     //
     // These are the defaults.


### PR DESCRIPTION
**What this PR does**:

- Create a separate config object for the Alertmanager storage backend

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
