### PR TITLE
Sort legend descending in the CPU/memory panels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   git branch -u origin/main main
   ```
 * [ENHANCEMENT] Add `EtcdAllocatingTooMuchMemory` alert for monitoring etcd memory usage. #261
+* [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271
 
 ## 1.7.0 / 2021-02-24
 

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -139,6 +139,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           fill: 0,
         },
       ],
+      tooltip: { sort: 2 },  // Sort descending.
     },
 
   containerMemoryWorkingSetPanel(title, containerName)::
@@ -158,6 +159,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
       ],
       yaxes: $.yaxes('bytes'),
+      tooltip: { sort: 2 },  // Sort descending.
     },
 
   goHeapInUsePanel(title, jobName)::
@@ -166,7 +168,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       'sum by(%s) (go_memstats_heap_inuse_bytes{%s})' % [$._config.per_instance_label, $.jobMatcher(jobName)],
       '{{%s}}' % $._config.per_instance_label
     ) +
-    { yaxes: $.yaxes('bytes') },
+    {
+      yaxes: $.yaxes('bytes'),
+      tooltip: { sort: 2 },  // Sort descending.
+    },
 
   // Switches a panel from lines (default) to bars.
   bars:: {

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -35,7 +35,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.queryPanel(
           'sum by(%s) (cortex_ingester_memory_series{%s})' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)],
           '{{%s}}' % $._config.per_instance_label
-        ),
+        ) +
+        {
+          tooltip: { sort: 2 },  // Sort descending.
+        },
       )
       .addPanel(
         $.containerCPUUsagePanel('CPU', 'ingester'),


### PR DESCRIPTION
**What this PR does**:
When having many replicas, it's useful to sort legend descending, so you can quickly see how is using high memory/CPU.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
