### PR TITLE
Add slow queries dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   git fetch origin
   git branch -u origin/main main
   ```
+* [FEATURE] Added "Cortex / Slow queries" dashboard based on Loki logs. #271
 * [ENHANCEMENT] Add `EtcdAllocatingTooMuchMemory` alert for monitoring etcd memory usage. #261
 * [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271
 * [BUGFIX] Fixed `CortexQuerierHighRefetchRate` alert. #268

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -7,6 +7,7 @@
     (import 'dashboards/alertmanager.libsonnet') +
     (import 'dashboards/scaling.libsonnet') +
     (import 'dashboards/writes.libsonnet') +
+    (import 'dashboards/slow-queries.libsonnet') +
 
     (if std.member($._config.storage_engine, 'blocks')
      then

--- a/cortex-mixin/dashboards/slow-queries.libsonnet
+++ b/cortex-mixin/dashboards/slow-queries.libsonnet
@@ -51,7 +51,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               id: 'organize',
               options: {
                 // Hide fields we don't care.
-                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'org_id', 'param_end', 'param_start', 'param_time', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs'],
+                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'param_end', 'param_start', 'param_time', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs'],
 
                 excludeByName: {
                   [field]: true
@@ -59,7 +59,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 },
 
                 // Order fields.
-                local orderedFields = ['ts', 'param_query', 'Time range', 'param_step', 'response_time'],
+                local orderedFields = ['ts', 'org_id', 'param_query', 'Time range', 'param_step', 'response_time'],
 
                 indexByName: {
                   [orderedFields[i]]: i
@@ -68,6 +68,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
                 // Rename fields.
                 renameByName: {
+                  org_id: 'Tenant ID',
                   param_query: 'Query',
                   param_step: 'Step',
                   response_time: 'Duration',

--- a/cortex-mixin/dashboards/slow-queries.libsonnet
+++ b/cortex-mixin/dashboards/slow-queries.libsonnet
@@ -1,0 +1,184 @@
+local utils = import 'mixin-utils/utils.libsonnet';
+
+(import 'dashboard-utils.libsonnet') {
+  'cortex-slow-queries.json':
+    ($.dashboard('Cortex / Slow Queries') + { uid: 'e6f3091e29d2636e3b8393447e925668' })
+    .addClusterSelectorTemplates(false)
+    .addRow(
+      $.row('')
+      .addPanel(
+        {
+          title: 'Slow queries',
+          type: 'table',
+          datasource: '${lokidatasource}',
+
+          // Query logs from Loki.
+          targets: [
+            {
+              // Filter out the remote read endpoint.
+              expr: '{cluster=~"$cluster",namespace=~"$namespace",name="query-frontend"} |= "query stats" != "/api/v1/read" | logfmt | org_id=~"${tenant_id}" | response_time > ${min_duration}',
+              instant: false,
+              legendFormat: '',
+              range: true,
+              refId: 'A',
+            },
+          ],
+
+          // Use Grafana transformations to display fields in a table.
+          transformations: [
+            {
+              // Convert labels to fields.
+              id: 'labelsToFields',
+              options: {},
+            },
+            {
+              // Compute the query time range.
+              id: 'calculateField',
+              options: {
+                alias: 'Time range',
+                mode: 'binary',
+                binary: {
+                  left: 'param_end',
+                  operator: '-',
+                  reducer: 'sum',
+                  right: 'param_start',
+                },
+                reduce: { reducer: 'sum' },
+                replaceFields: false,
+              },
+            },
+            {
+              id: 'organize',
+              options: {
+                // Hide fields we don't care.
+                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'org_id', 'param_end', 'param_start', 'param_time', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs'],
+
+                excludeByName: {
+                  [field]: true
+                  for field in hiddenFields
+                },
+
+                // Order fields.
+                local orderedFields = ['ts', 'param_query', 'Time range', 'param_step', 'response_time'],
+
+                indexByName: {
+                  [orderedFields[i]]: i
+                  for i in std.range(0, std.length(orderedFields) - 1)
+                },
+
+                // Rename fields.
+                renameByName: {
+                  param_query: 'Query',
+                  param_step: 'Step',
+                  response_time: 'Duration',
+                },
+              },
+            },
+          ],
+
+          fieldConfig: {
+            // Configure overrides to nicely format field values.
+            overrides: [
+              {
+                matcher: { id: 'byName', options: 'Time range' },
+                properties: [
+                  {
+                    id: 'mappings',
+                    value: [
+                      {
+                        from: '',
+                        id: 1,
+                        text: 'Instant query',
+                        to: '',
+                        type: 1,
+                        value: '0',
+                      },
+                    ],
+                  },
+                  { id: 'unit', value: 's' },
+                ],
+              },
+              {
+                matcher: { id: 'byName', options: 'Step' },
+                properties: [{ id: 'unit', value: 's' }],
+              },
+            ],
+          },
+        },
+      )
+    )
+    + {
+      templating+: {
+        list+: [
+          // Add the Loki datasource.
+          {
+            type: 'datasource',
+            name: 'lokidatasource',
+            label: 'Logs datasource',
+            query: 'loki',
+            hide: 0,
+            includeAll: false,
+            multi: false,
+          },
+          // Add a variable to configure the min duration.
+          {
+            local defaultValue = '5s',
+
+            type: 'textbox',
+            name: 'min_duration',
+            label: 'Min duration',
+            hide: 0,
+            options: [
+              {
+                selected: true,
+                text: defaultValue,
+                value: defaultValue,
+              },
+            ],
+            current: {
+              // Default value.
+              selected: true,
+              text: defaultValue,
+              value: defaultValue,
+            },
+            query: defaultValue,
+          },
+          // Add a variable to configure the tenant to filter on.
+          {
+            local defaultValue = '.*',
+
+            type: 'textbox',
+            name: 'tenant_id',
+            label: 'Tenant ID',
+            hide: 0,
+            options: [
+              {
+                selected: true,
+                text: defaultValue,
+                value: defaultValue,
+              },
+            ],
+            current: {
+              // Default value.
+              selected: true,
+              text: defaultValue,
+              value: defaultValue,
+            },
+            query: defaultValue,
+          },
+        ],
+      },
+    } + {
+      templating+: {
+        list: [
+          // Do not allow to include all clusters/namespaces otherwise this dashboard
+          // risks to explode because it shows resources per pod.
+          l + (if (l.name == 'cluster' || l.name == 'namespace') then { includeAll: false } else {})
+          for l in super.list
+        ],
+      },
+    } + {
+      // No auto-refresh by default.
+      refresh: '',
+    },
+}


### PR DESCRIPTION
**What this PR does**:
I've built a dashboard to show slow queries querying logs with Loki. Below you can find an example:

![Screenshot 2021-03-16 at 12 26 40](https://user-images.githubusercontent.com/1701904/111301808-ec031f80-8652-11eb-91e1-b7a6560e0669.png)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
