### PR TITLE
Fix ingester statefulset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271
 * [ENHANCEMENT] Add config option to enable streaming of chunks in block-based ingesters. #276
 * [BUGFIX] Fixed `CortexQuerierHighRefetchRate` alert. #268
+* [BUGFIX] Fixed `ingester_statefulset` overrides in `tsdb.libsonnet`. #274
 
 ## 1.7.0 / 2021-02-24
 

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -126,7 +126,7 @@
     // ready).
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
 
-  ingester_statefulset: self.newIngesterStatefulSet('ingester', $.ingester_container),
+  ingester_statefulset: self.newIngesterStatefulSet('ingester', $.ingester_statefulset_container),
 
   ingester_service:
     $.util.serviceFor($.ingester_statefulset, $.ingester_service_ignored_labels),


### PR DESCRIPTION
**What this PR does**:

Use the `$.ingester_statefulset_container` to override the `ingester_statefulset` in `tsdb.libsonnet`

**Which issue(s) this PR fixes**:
Fixes #274

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
