### PR TITLE
Add recording rules to calculate Cortex scaling

### DIFF
--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -58,6 +58,207 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         ],
       },
+      {
+        local _config = {
+          max_series_per_ingester: 1.5e6,
+          max_samples_per_sec_per_ingester: 80e3,
+          max_samples_per_sec_per_distributor: 240e3,
+          limit_utilisation_target: 0.6,
+        },
+        name: 'cortex_scaling_rules',
+        rules: [
+          {
+            // Convenience rule to get the number of replicas for both a deployment and a statefulset.
+            record: 'cluster_namespace_deployment:actual_replicas:count',
+            expr: |||
+              sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas)
+                or
+              sum by (cluster, namespace, deployment) (
+                label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*)")
+              )
+            |||,
+          },
+          {
+            // Distributors should be able to deal with 240k samples/s.
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'distributor',
+              reason: 'sample_rate',
+            },
+            expr: |||
+              ceil(
+                quantile_over_time(0.99,
+                  sum by (cluster, namespace) (
+                    cluster_namespace_job:cortex_distributor_received_samples:rate5m
+                  )[24h:]
+                )
+                / %(max_samples_per_sec_per_distributor)s
+              )
+            ||| % _config,
+          },
+          {
+            // We should be about to cover 80% of our limits,
+            // and ingester can have 80k samples/s.
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'distributor',
+              reason: 'sample_rate_limits',
+            },
+            expr: |||
+              ceil(
+                sum by (cluster, namespace) (cortex_overrides{limit_name="ingestion_rate"})
+                * %(limit_utilisation_target)s / %(max_samples_per_sec_per_distributor)s
+              )
+            ||| % _config,
+          },
+          {
+            // We want ingesters each ingester to deal with 80k samples/s.
+            // NB we measure this at the distributors and multiple by RF (3).
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'ingester',
+              reason: 'sample_rate',
+            },
+            expr: |||
+              ceil(
+                quantile_over_time(0.99,
+                  sum by (cluster, namespace) (
+                    cluster_namespace_job:cortex_distributor_received_samples:rate5m
+                  )[24h:]
+                )
+                * 3 / %(max_samples_per_sec_per_ingester)s
+              )
+            ||| % _config,
+          },
+          {
+            // Ingester should have 1.5M series in memory
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'ingester',
+              reason: 'active_series',
+            },
+            expr: |||
+              ceil(
+                quantile_over_time(0.99,
+                  sum by(cluster, namespace) (
+                    cortex_ingester_memory_series
+                  )[24h:]
+                )
+                / %(max_series_per_ingester)s
+              )
+            ||| % _config,
+          },
+          {
+            // We should be about to cover 60% of our limits,
+            // and ingester can have 1.5M series in memory
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'ingester',
+              reason: 'active_series_limits',
+            },
+            expr: |||
+              ceil(
+                sum by (cluster, namespace) (cortex_overrides{limit_name="max_global_series_per_user"})
+                * 3 * %(limit_utilisation_target)s / %(max_series_per_ingester)s
+              )
+            ||| % _config,
+          },
+          {
+            // We should be about to cover 60% of our limits,
+            // and ingester can have 80k samples/s.
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'ingester',
+              reason: 'sample_rate_limits',
+            },
+            expr: |||
+              ceil(
+                sum by (cluster, namespace) (cortex_overrides{limit_name="ingestion_rate"})
+                * %(limit_utilisation_target)s / %(max_samples_per_sec_per_ingester)s
+              )
+            ||| % _config,
+          },
+          {
+            // Ingesters store 96h of data on disk - we want memcached to store 1/4 of that.
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              deployment: 'memcached',
+              reason: 'active_series',
+            },
+            expr: |||
+              ceil(
+                (sum by (cluster, namespace) (
+                  cortex_ingester_tsdb_storage_blocks_bytes{job=~".+/ingester"}
+                ) / 4)
+                  /
+                avg by (cluster, namespace) (
+                  memcached_limit_bytes{job=~".+/memcached"}
+                )
+              )
+            |||,
+          },
+          {
+            // Jobs should be sized to their CPU usage.
+            // We do this by comparing 99th percentile usage over the last 24hrs to
+            // their current provisioned #replicas and resource requests.
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              reason: 'cpu_usage',
+            },
+            expr: |||
+              ceil(
+                cluster_namespace_deployment:actual_replicas:count
+                  *
+                quantile_over_time(0.99,
+                  sum by (cluster, namespace, deployment) (
+                    label_replace(
+                      node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate,
+                      "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    )
+                  )[24h:5m]
+                )
+                  /
+                sum by (cluster, namespace, deployment) (
+                  label_replace(
+                    kube_pod_container_resource_requests_cpu_cores,
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  )
+                )
+              )
+            |||,
+          },
+          {
+            // Jobs should be sized to their Memory usage.
+            // We do this by comparing 99th percentile usage over the last 24hrs to
+            // their current provisioned #replicas and resource requests.
+            record: 'cluster_namespace_deployment_reason:required_replicas:count',
+            labels: {
+              reason: 'memory_usage',
+            },
+            expr: |||
+              ceil(
+                cluster_namespace_deployment:actual_replicas:count
+                  *
+                quantile_over_time(0.99,
+                  sum by (cluster, namespace, deployment) (
+                    label_replace(
+                      container_memory_usage_bytes,
+                      "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    )
+                  )[24h:5m]
+                )
+                  /
+                sum by (cluster, namespace, deployment) (
+                  label_replace(
+                    kube_pod_container_resource_requests_memory_bytes,
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  )
+                )
+              )
+            |||,
+          },
+        ],
+      },
     ],
   },
 }

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -43,7 +43,7 @@
     ),
 
   ingester_statefulset_args::
-    $._config.grpcConfig +
+    $._config.grpcConfig
     {
       'ingester.wal-enabled': true,
       'ingester.checkpoint-enabled': true,

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -2,7 +2,7 @@
   local container = $.core.v1.container,
 
   query_frontend_args::
-    $._config.grpcConfig +
+    $._config.grpcConfig
     {
       target: 'query-frontend',
 
@@ -38,17 +38,17 @@
       'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
     } + (
       if $._config.queryFrontend.sharded_queries_enabled then
-      {
-        'querier.parallelise-shardable-queries': 'true',
+        {
+          'querier.parallelise-shardable-queries': 'true',
 
-        // in process tenant queues on frontends. We divide by the number of frontends; 2 in this case in order to apply the global limit in aggregate.
-        // basically base * shard_factor * query_split_factor / num_frontends where
-        'querier.max-outstanding-requests-per-tenant': std.floor(200 * $._config.queryFrontend.shard_factor * $._config.queryFrontend.query_split_factor / $._config.queryFrontend.replicas),
+          // in process tenant queues on frontends. We divide by the number of frontends; 2 in this case in order to apply the global limit in aggregate.
+          // basically base * shard_factor * query_split_factor / num_frontends where
+          'querier.max-outstanding-requests-per-tenant': std.floor(200 * $._config.queryFrontend.shard_factor * $._config.queryFrontend.query_split_factor / $._config.queryFrontend.replicas),
 
-        'querier.query-ingesters-within': $._config.queryConfig['querier.query-ingesters-within'],
-      } + $._config.storageConfig
-    else {}
-  ),
+          'querier.query-ingesters-within': $._config.queryConfig['querier.query-ingesters-within'],
+        } + $._config.storageConfig
+      else {}
+    ),
 
   query_frontend_container::
     container.new('query-frontend', $._images.query_frontend) +


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

**What this PR does**:

Extracts the queries from the scaling dashboard so we can do:

```
sort_desc(cluster_namespace_deployment_reason:required_replicas:count{namespace=~"cortex.*"} ​> ignoring(reason) group_left cluster_namespace_deployment:actual_replicas:count)
```

And eventually alert on this.
