### PR TITLE
Increased CortexRequestErrors alert severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   git fetch origin
   git branch -u origin/main main
   ```
-* [CHANGE] `CortexRequestErrors` alert severity raised from `warning` to `critical`. #278
+* [CHANGE] `CortexRequestErrors` alert severity raised from `warning` to `critical`. #279
 * [FEATURE] Added "Cortex / Slow queries" dashboard based on Loki logs. #271
 * [ENHANCEMENT] Add `EtcdAllocatingTooMuchMemory` alert for monitoring etcd memory usage. #261
 * [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   git fetch origin
   git branch -u origin/main main
   ```
+* [CHANGE] `CortexRequestErrors` alert severity raised from `warning` to `critical`. #278
 * [FEATURE] Added "Cortex / Slow queries" dashboard based on Loki logs. #271
 * [ENHANCEMENT] Add `EtcdAllocatingTooMuchMemory` alert for monitoring etcd memory usage. #261
 * [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -18,7 +18,7 @@
         },
         {
           alert: 'CortexRequestErrors',
-          // Note is alert_aggregation_labels is "job", this will repeat the label.  But
+          // Note if alert_aggregation_labels is "job", this will repeat the label. But
           // prometheus seems to tolerate that.
           expr: |||
             100 * sum by (%s, job, route) (rate(cortex_request_duration_seconds_count{status_code=~"5..",route!~"ready"}[1m]))
@@ -28,7 +28,7 @@
           ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
           'for': '15m',
           labels: {
-            severity: 'warning',
+            severity: 'critical',
           },
           annotations: {
             message: |||


### PR DESCRIPTION
**What this PR does**:
The `CortexRequestErrors` alert looks to be quite critical. If it triggers, it means > 1% of requests to a specific route are failing for 15 consecutive minutes.

What's the sentiment if we raise it to `critical`?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
