### PR TITLE
Fixed "Disk Writes" and "Disk Reads" panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271
 * [ENHANCEMENT] Add config option to enable streaming of chunks in block-based ingesters. #276
 * [BUGFIX] Fixed `CortexQuerierHighRefetchRate` alert. #268
-* [BUGFIX] Fixed "Disk Writes" and "Disk Reads" panels.
+* [BUGFIX] Fixed "Disk Writes" and "Disk Reads" panels. #280
 
 ## 1.7.0 / 2021-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Sort legend descending in the CPU/memory panels. #271
 * [ENHANCEMENT] Add config option to enable streaming of chunks in block-based ingesters. #276
 * [BUGFIX] Fixed `CortexQuerierHighRefetchRate` alert. #268
+* [BUGFIX] Fixed "Disk Writes" and "Disk Reads" panels.
 
 ## 1.7.0 / 2021-02-24
 

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -45,7 +45,10 @@
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
     resources_dashboards_enabled: false,
 
-    // Used on panels that show metrics per instance.  i.e. 'pod' in a kubernetes install
+    // The label used to differentiate between different application instances (i.e. 'pod' in a kubernetes install).
     per_instance_label: 'pod',
+
+    // The label used to differentiate between different nodes (i.e. servers).
+    per_node_label: 'instance',
   },
 }

--- a/cortex-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager-resources.libsonnet
@@ -60,7 +60,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Writes') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('alertmanager')],
+          'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('alertmanager')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +
@@ -69,7 +69,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Reads') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('alertmanager')],
+          'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('alertmanager')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +

--- a/cortex-mixin/dashboards/compactor-resources.libsonnet
+++ b/cortex-mixin/dashboards/compactor-resources.libsonnet
@@ -36,7 +36,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Disk Writes') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('compactor')],
+          'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('compactor')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +
@@ -45,7 +45,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Disk Reads') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('compactor')],
+          'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('compactor')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -257,9 +257,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { yaxes: $.yaxes('percentunit') },
     ),
 
-
   filterNodeDiskContainer(containerName)::
     |||
-      ignoring(%s) group_right() (label_replace(count by(%s, device) (container_fs_writes_bytes_total{%s,container="%s",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
-    ||| % [$._config.per_instance_label, $._config.per_instance_label, $.namespaceMatcher(), containerName],
+      ignoring(%s) group_right() (label_replace(count by(%s, %s, device) (container_fs_writes_bytes_total{%s,container="%s",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
+    ||| % [$._config.per_instance_label, $._config.per_node_label, $._config.per_instance_label, $.namespaceMatcher(), containerName],
 }

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -105,7 +105,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Disk Writes') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('store-gateway')],
+          'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('store-gateway')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +
@@ -114,7 +114,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Disk Reads') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('store-gateway')],
+          'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('store-gateway')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -58,7 +58,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Disk Writes') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('ingester')],
+          'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('ingester')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +
@@ -67,7 +67,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Disk Reads') +
         $.queryPanel(
-          'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_instance_label, $.filterNodeDiskContainer('ingester')],
+          'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDiskContainer('ingester')],
           '{{%s}} - {{device}}' % $._config.per_instance_label
         ) +
         $.stack +


### PR DESCRIPTION
**What this PR does**:
The "Disk Writes" and "Disk Reads" panels are showing incorrect numbers because we currently sum `node_disk_written_bytes_total` and `node_disk_read_bytes_total` metrics by device only and not by device + node, so basically if a pod is using `sdb` we show the sum of `sdb` across all nodes.

This PR fixes it (I've manually tested it in our infra).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
