### PR TITLE
chore: update lib to use new API paths

### DIFF
--- a/cortex/test-exporter.libsonnet
+++ b/cortex/test-exporter.libsonnet
@@ -4,7 +4,7 @@
 
   test_exporter_args:: {
     'user-id': $._config.test_exporter_user_id,
-    'prometheus-address': 'http://query-frontend.%(namespace)s.svc.cluster.local/api/prom' % $._config,
+    'prometheus-address': 'http://query-frontend.%(namespace)s.svc.cluster.local/prometheus' % $._config,
     'test-query-start': $._config.test_exporter_start_time,
     'extra-selectors': 'job="%(namespace)s/test-exporter"' % $._config,
     'test-query-min-size': '1m',


### PR DESCRIPTION
**What this PR does**:

- Part of a larger effort in replacing references to `/api/prom` in favor of `/prometheus` from documentation and tooling.

See https://github.com/cortexproject/cortex/pull/4004 for example