### PR TITLE
Restrict recording rules to Cortex containers

### DIFF
--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -37,6 +37,28 @@
       gateway: 'cortex-gw',
     },
 
+    // Container names of all services managed / used by this mixin.
+    container_names: [
+      // Cortex services.
+      'distributor',
+      'ingester',
+      'query-frontend',
+      'querier',
+      'store-gateway',
+      'compactor',
+      'alertmanager',
+      'ruler',
+      'table-manager',
+
+      // Ingress.
+      'cortex-gw.*',
+
+      // Dependencies.
+      'memcached',
+      'consul',
+      'etcd',
+    ],
+
     // Labels used to in alert aggregations - should uniquely identify
     // a single Cortex cluster.
     alert_aggregation_labels: 'cluster, namespace',


### PR DESCRIPTION
**What this PR does**:
The PR #278 has added new recording rules for the scaling dashboard. In our infrastructure, the recording rules for `cpu_usage` and `memory_usage` are slow to evaluate (takes about 1m each) because they run for every container, not just Cortex ones.

In this PR I'm proposing to run them only for Cortex containers. If this is not the right approach to fix it, what do you suggest?

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
