### PR TITLE
Do not use deprecated Alertmanager cluster flags

### DIFF
--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -61,8 +61,8 @@
       container.withArgsMixin(
         $.util.mapToFlags($.alertmanager_args) +
         if isHA then
-          ['--cluster.listen-address=[$(POD_IP)]:%s' % $._config.alertmanager.gossip_port] +
-          ['--cluster.peer=%s' % peer for peer in peers]
+          ['--alertmanager.cluster.listen-address=[$(POD_IP)]:%s' % $._config.alertmanager.gossip_port] +
+          ['--alertmanager.cluster.peers=%s' % peer for peer in peers]
         else [],
       ) +
       container.withVolumeMountsMixin(


### PR DESCRIPTION
**What this PR does**:
In this PR I'm replacing the deprecated Alertmanager cluster flags with new ones.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
