### PR TITLE
fix: Update ksonnet-util vendor lock

### DIFF
--- a/cortex/jsonnetfile.lock.json
+++ b/cortex/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "c19a92e586a6752f11745b47f309b13f02ef7147",
-      "sum": "LKsTTBcH8TXX5ANgRUu5I7Y1tf5le4nANFV3/W53I+c="
+      "version": "8fa7669cc7b1b1822eb0220f2eda9c6aaa5c5119",
+      "sum": "/l/RofjusGrnNpJMD0ST+jDgtARyjvBP5vC7kEjPoQI="
     },
     {
       "source": {


### PR DESCRIPTION
**What this PR does**:

The previous version `c19a92e586a6752f11745b47f309b13f02ef7147` is
incompatible with the library in its current form. For example in
`tsdb.libsonnet` L81, we use `pvc.new('ingester-pvc')` but at the
locked version, in `ksonnet-util/kausal.libsonnet` the `pvc.new`
function takes no arguments.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
