### PR TITLE
Fixed CortexCompactorRunFailed threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [ENHANCEMENT] Added `newCompactorStatefulSet()` function to create a custom statefulset for the compactor. #287
 * [ENHANCEMENT] Added option to configure compactor job name used in dashboards and alerts. #287
+* [BUGFIX] Fixed `CortexCompactorRunFailed` false positives. #288
 
 ## 1.8.0 / 2021-03-25
 

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -67,7 +67,7 @@
           // Alert if compactor fails.
           alert: 'CortexCompactorRunFailed',
           expr: |||
-            increase(cortex_compactor_runs_failed_total[2h]) > 1
+            increase(cortex_compactor_runs_failed_total[2h]) >= 2
           |||,
           labels: {
             severity: 'critical',


### PR DESCRIPTION
**What this PR does**:
Due to interpolation, the computed `increase(cortex_compactor_runs_failed_total[2h])` may be slight higher than 1 (eg. `1.001`) so checking for `>= 2` (instead of `> 1`) fixes such false positives.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
