### PR TITLE
Fix 'Unhealthy pods' in Cortex Rollout dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master / unreleased
 
-* [FEATURE] Added "Cortex / Rollout progress" dashboard. #289
+* [FEATURE] Added "Cortex / Rollout progress" dashboard. #289 #290
 * [ENHANCEMENT] Added `newCompactorStatefulSet()` function to create a custom statefulset for the compactor. #287
 * [ENHANCEMENT] Added option to configure compactor job name used in dashboards and alerts. #287
 * [BUGFIX] Fixed `CortexCompactorRunFailed` false positives. #288

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -173,7 +173,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       tooltip: { sort: 2 },  // Sort descending.
     },
 
-  newStatPanel(queries, legends='', unit='percentunit', thresholds=[], instant=false, novalue='')::
+  newStatPanel(queries, legends='', unit='percentunit', decimals=1, thresholds=[], instant=false, novalue='')::
     super.queryPanel(queries, legends) + {
       type: 'stat',
       targets: [
@@ -191,7 +191,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       fieldConfig: {
         defaults: {
           color: { mode: 'thresholds' },
-          decimals: 1,
+          decimals: decimals,
           thresholds: {
             mode: 'absolute',
             steps: thresholds,

--- a/cortex-mixin/dashboards/rollout-progress.libsonnet
+++ b/cortex-mixin/dashboards/rollout-progress.libsonnet
@@ -177,7 +177,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           { color: 'green', value: null },
           { color: 'orange', value: 1 },
           { color: 'red', value: 2 },
-        ], instant=true, novalue='All healthy') + {
+        ], instant=true, novalue='All healthy', unit='short', decimals=0) + {
           options: {
             text: {
               // Small font size since we may have many entries during a rollout.


### PR DESCRIPTION
**What this PR does**:
`newStatPanel()` defaults the unit to percentage, while the "Unhealthy pods" panel in the "Cortex / Rollout progress" dashboard should just display the integer number (`short` unit). This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
