### PR TITLE
Add querier_service_ignored_labels

### DIFF
--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -61,6 +61,8 @@
 
   local service = $.core.v1.service,
 
+  querier_service_ignored_labels:: [],
+
   querier_service:
-    $.util.serviceFor($.querier_deployment),
+    $.util.serviceFor($.querier_deployment, $.querier_service_ignored_labels),
 }


### PR DESCRIPTION
**What this PR does**:

`querier_service_ignored_labels` is used in `gossip.libsonnet` but not defined in `querier.libsonnet`.
