### PR TITLE
Use new compaction interval metric in compaction failed alert.

### DIFF
--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -65,7 +65,8 @@
           // Alert if compactor fails.
           alert: 'CortexCompactorRunFailed',
           expr: |||
-            increase(cortex_compactor_runs_failed_total[2h]) >= 2
+            (time() - cortex_compactor_last_successful_run_timestamp_seconds) > 
+            (cortex_compactor_compaction_interval_seconds * 2)
           |||,
           labels: {
             severity: 'critical',


### PR DESCRIPTION
Signed-off-by: Callum Styan <callumstyan@gmail.com>

**What this PR does**:
Changes compaction failed alert to use new `cortex_compactor_compaction_interval_seconds` metric, so that we can more accurately alert when two compactions in a row have failed, regardless of whether the compaction interval is 2h (the value currently used within the increase function of the alert) or not.

Not sure if there should be a changelog entry here.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
