### PR TITLE
Fix CortexCompactorHasNotSuccessfullyRunCompaction to avoid false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Added "Cortex / Rollout progress" dashboard. #289 #290
 * [ENHANCEMENT] Added `newCompactorStatefulSet()` function to create a custom statefulset for the compactor. #287
 * [ENHANCEMENT] Added option to configure compactor job name used in dashboards and alerts. #287
+* [ENHANCEMENT] Added `CortexCompactorHasNotSuccessfullyRunCompaction` alert. #292 #294
 * [BUGFIX] Fixed `CortexCompactorRunFailed` false positives. #288
 
 ## 1.8.0 / 2021-03-25

--- a/cortex-mixin/alerts/compactor.libsonnet
+++ b/cortex-mixin/alerts/compactor.libsonnet
@@ -18,17 +18,33 @@
           },
         },
         {
-          // Alert if the compactor has not successfully run compaction in the last 6h.
+          // Alert if the compactor has not successfully run compaction in the last 24h.
           alert: 'CortexCompactorHasNotSuccessfullyRunCompaction',
           'for': '1h',
           expr: |||
-            time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 6
+            (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
+            and
+            (cortex_compactor_last_successful_run_timestamp_seconds > 0)
           |||,
           labels: {
             severity: 'critical',
           },
           annotations: {
-            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not run compaction in the last 6 hours.',
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not run compaction in the last 24 hours.',
+          },
+        },
+        {
+          // Alert if the compactor has not successfully run compaction in the last 24h since startup.
+          alert: 'CortexCompactorHasNotSuccessfullyRunCompaction',
+          'for': '24h',
+          expr: |||
+            cortex_compactor_last_successful_run_timestamp_seconds == 0
+          |||,
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cortex Compactor {{ $labels.namespace }}/{{ $labels.instance }} has not run compaction in the last 24 hours.',
           },
         },
         {


### PR DESCRIPTION
**What this PR does**:
Yesterday we merged #292 but I just realised it suffers false positives. The reason is that a compaction run is marked as done once there's no more work to do for the compactor. Because of this it could take even a long time (several hours) while the compactor is working flawlessly  as expected. Moreover, after startup the metric `cortex_compactor_last_successful_run_timestamp_seconds` value will be `0` until the first compaction run as completed (which, again, could take hours).

In this PR:
1. Increase threshold to 24h
2. Cover the case of the metric == 0 right after startup (while the 1st compaction run is on-going)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
