### PR TITLE
Improve CortexRulerFailedRingCheck alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] Added alerts for ingester reaching the instance limits (if limits are configured). #296:
   * `CortexIngesterReachingSeriesLimit`
   * `CortexIngesterReachingTenantsLimit`
-* [ENHANCEMENT] Improved `CortexRulerFailedRingCheck` to avoid firing in case of very short errors. #294
+* [ENHANCEMENT] Improved `CortexRulerFailedRingCheck` to avoid firing in case of very short errors. #297
 * [BUGFIX] Fixed `CortexCompactorRunFailed` false positives. #288
 
 ## 1.8.0 / 2021-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Added alerts for ingester reaching the instance limits (if limits are configured). #296:
   * `CortexIngesterReachingSeriesLimit`
   * `CortexIngesterReachingTenantsLimit`
+* [ENHANCEMENT] Improved `CortexRulerFailedRingCheck` to avoid firing in case of very short errors. #294
 * [BUGFIX] Fixed `CortexCompactorRunFailed` false positives. #288
 
 ## 1.8.0 / 2021-03-25

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -560,16 +560,16 @@
         {
           alert: 'CortexRulerFailedRingCheck',
           expr: |||
-            sum by (%s) (rate(cortex_ruler_ring_check_errors_total[5m]))
+            sum by (%s, job) (rate(cortex_ruler_ring_check_errors_total[1m]))
                > 0
           ||| % $._config.alert_aggregation_labels,
-          'for': '1m',
+          'for': '5m',
           labels: {
             severity: 'critical',
           },
           annotations: {
             message: |||
-              {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% errors when checking the ring for rule group ownership.
+              Cortex Rulers {{ $labels.job }} are experiencing errors when checking the ring for rule group ownership.
             |||,
           },
         },


### PR DESCRIPTION
**What this PR does**:
We've seen the `CortexRulerFailedRingCheck` critical alert to fire even in case of very short errors (eg. less than 2 minutes) due to multiple rulers restarting at the same time (eg. OOMKilled). I would suggest to raise this alert in case of errors for 5 consecutive minutes, in order to reduce the noise.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
