### PR TITLE
feat: Allow configuration of ring members in gossip alerts

### DIFF
--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -593,8 +593,8 @@
           expr: |||
             memberlist_client_cluster_members_count
               != on (%s) group_left
-            sum by (%s) (up{job=~".+/(admin-api|compactor|store-gateway|distributor|ingester.*|querier.*|cortex|ruler)"})
-          ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels],
+            sum by (%s) (up{job=~".+/%s"})
+          ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels, $._config.job_names.ring_members],
           'for': '5m',
           labels: {
             severity: 'warning',

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -1,4 +1,9 @@
 {
+  // simpleRegexpOpt produces a simple regexp that matches all strings in the input array.
+  local simpleRegexpOpt(strings) =
+    assert std.isArray(strings) : 'simpleRegexpOpt requires that `strings` is an array of strings`';
+    '(' + std.join('|', strings) + ')',
+
   groups+: [
     {
       name: 'cortex_alerts',
@@ -590,11 +595,12 @@
       rules: [
         {
           alert: 'CortexGossipMembersMismatch',
-          expr: |||
-            memberlist_client_cluster_members_count
-              != on (%s) group_left
-            sum by (%s) (up{job=~".+/%s"})
-          ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels, $._config.job_names.ring_members],
+          expr:
+            |||
+              memberlist_client_cluster_members_count
+                != on (%s) group_left
+              sum by (%s) (up{job=~".+/%s"})
+            ||| % [$._config.alert_aggregation_labels, $._config.alert_aggregation_labels, simpleRegexpOpt($._config.job_names.ring_members)],
           'for': '5m',
           labels: {
             severity: 'warning',

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,7 +33,9 @@
       query_frontend: '(query-frontend.*|cortex$)',  // Match also custom query-frontend deployments.
       query_scheduler: 'query-scheduler.*',  // Not part of single-binary. Match also custom query-scheduler deployments.
       table_manager: '(table-manager|cortex$)',
-      ring_members: '(compactor|distributor|ingester|querier|ruler|store-gateway|cortex)',
+      // ingester-.* accommodates multiple ingester StatefulSets or Deployments.
+      // cortex$ prevents matching the cortex-gateway.
+      ring_members: '(compactor|distributor|ingester-.*|querier|ruler|store-gateway|cortex$)',
       store_gateway: '(store-gateway|cortex$)',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*',  // Match also custom compactor deployments.

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,9 +33,13 @@
       query_frontend: '(query-frontend.*|cortex$)',  // Match also custom query-frontend deployments.
       query_scheduler: 'query-scheduler.*',  // Not part of single-binary. Match also custom query-scheduler deployments.
       table_manager: '(table-manager|cortex$)',
+      // If non-null, this list is joined together to form the regexp for the ring_members matcher value.
+      // to completely, override the matcher value, you can make this null and override the `ring_members`
+      // field instead of this.
       // ingester-.* accommodates multiple ingester StatefulSets or Deployments.
       // cortex$ prevents matching the cortex-gateway.
-      ring_members: '(compactor|distributor|ingester-.*|querier|ruler|store-gateway|cortex$)',
+      ring_members_list: ['compactor', 'distributor', 'ingester-.*', 'querier', 'ruler', 'store-gateway', 'cortex$'],
+      ring_members: if self.ring_members_list != null then '(%s)' % std.join('|', self.ring_members_list) else '',
       store_gateway: '(store-gateway|cortex$)',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*',  // Match also custom compactor deployments.

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,7 +33,7 @@
       query_frontend: '(query-frontend.*|cortex$)',  // Match also custom query-frontend deployments.
       query_scheduler: 'query-scheduler.*',  // Not part of single-binary. Match also custom query-scheduler deployments.
       table_manager: '(table-manager|cortex$)',
-      ring_members: ['compactor', 'distributor', 'ingester-.*', 'querier', 'ruler', 'store-gateway', 'cortex'],
+      ring_members: ['compactor', 'distributor', 'ingester.*', 'querier.*', 'ruler', 'store-gateway', 'cortex'],
       store_gateway: '(store-gateway|cortex$)',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*',  // Match also custom compactor deployments.

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,6 +33,7 @@
       query_frontend: '(query-frontend.*|cortex$)',  // Match also custom query-frontend deployments.
       query_scheduler: 'query-scheduler.*',  // Not part of single-binary. Match also custom query-scheduler deployments.
       table_manager: '(table-manager|cortex$)',
+      ring_members: '(distributor|ingester|querier|cortex|ruler)',
       store_gateway: '(store-gateway|cortex$)',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*',  // Match also custom compactor deployments.

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,7 +33,7 @@
       query_frontend: '(query-frontend.*|cortex$)',  // Match also custom query-frontend deployments.
       query_scheduler: 'query-scheduler.*',  // Not part of single-binary. Match also custom query-scheduler deployments.
       table_manager: '(table-manager|cortex$)',
-      ring_members: '(distributor|ingester|querier|cortex|ruler)',
+      ring_members: '(compactor|distributor|ingester|querier|ruler|store-gateway|cortex)',
       store_gateway: '(store-gateway|cortex$)',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*',  // Match also custom compactor deployments.

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -33,13 +33,7 @@
       query_frontend: '(query-frontend.*|cortex$)',  // Match also custom query-frontend deployments.
       query_scheduler: 'query-scheduler.*',  // Not part of single-binary. Match also custom query-scheduler deployments.
       table_manager: '(table-manager|cortex$)',
-      // If non-null, this list is joined together to form the regexp for the ring_members matcher value.
-      // to completely, override the matcher value, you can make this null and override the `ring_members`
-      // field instead of this.
-      // ingester-.* accommodates multiple ingester StatefulSets or Deployments.
-      // cortex$ prevents matching the cortex-gateway.
-      ring_members_list: ['compactor', 'distributor', 'ingester-.*', 'querier', 'ruler', 'store-gateway', 'cortex$'],
-      ring_members: if self.ring_members_list != null then '(%s)' % std.join('|', self.ring_members_list) else '',
+      ring_members: ['compactor', 'distributor', 'ingester-.*', 'querier', 'ruler', 'store-gateway', 'cortex'],
       store_gateway: '(store-gateway|cortex$)',
       gateway: '(gateway|cortex-gw|cortex-gw-internal)',
       compactor: 'compactor.*',  // Match also custom compactor deployments.


### PR DESCRIPTION
**What this PR does**:
Allows library consumers to configure the names of jobs that are members of the gossip ring which is used by the CortexGossipMembersMismatch alert.

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
