### PR TITLE
Do not use deprecated flag -limits.per-user-override-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CHANGE] Replace use of removed Cortex CLI flag `-querier.compress-http-responses` for query frontend with `-api.response-compression-enabled`. #299
 * [CHANGE] The default dashboards config now display panels for the Cortex blocks storage only. If you're running Cortex chunks storage, please change `storage_engine` config to `['chunks']` or `['chunks', 'blocks']` if running both. #302
 * [CHANGE] Enabled index-header lazy loading in store-gateways. #303
+* [CHANGE] Replaced the deprecated CLI flag `-limits.per-user-override-config` (removed in Cortex 1.9) with `-runtime-config.file`. #304
 * [FEATURE] Added "Cortex / Rollout progress" dashboard. #289 #290
 * [FEATURE] Added support for using query-scheduler component, which moves the queue out of query-frontend, and allows scaling up of query-frontend component. #295
 * [ENHANCEMENT] Added `newCompactorStatefulSet()` function to create a custom statefulset for the compactor. #287

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -198,7 +198,7 @@
 
     // Shared between the Ruler and Querier
     queryConfig: {
-      'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '/etc/cortex/overrides.yaml',
 
       // Limit the size of the rows we read from the index.
       'store.cardinality-limit': 1e6,

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -11,7 +11,7 @@
 
       'validation.reject-old-samples': true,
       'validation.reject-old-samples.max-age': '12h',
-      'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '/etc/cortex/overrides.yaml',
       'distributor.remote-timeout': '20s',
 
       'distributor.ha-tracker.enable': true,

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -30,7 +30,7 @@
       'ingester.max-global-series-per-metric': $._config.limits.max_global_series_per_metric,
       'ingester.max-series-per-query': $._config.limits.max_series_per_query,
       'ingester.max-samples-per-query': $._config.limits.max_samples_per_query,
-      'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '/etc/cortex/overrides.yaml',
       'server.grpc-max-concurrent-streams': 100000,
     } + (
       if $._config.memcached_index_writes_enabled then

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -35,7 +35,7 @@
 
       // Limit queries to 500 days, allow this to be override per-user.
       'store.max-query-length': '12000h',  // 500 Days
-      'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '/etc/cortex/overrides.yaml',
     } + (
       if $._config.queryFrontend.sharded_queries_enabled then
         {

--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -207,7 +207,7 @@
     $._config.queryBlocksStorageConfig +
     {
       target: 'store-gateway',
-      'limits.per-user-override-config': '/etc/cortex/overrides.yaml',
+      'runtime-config.file': '/etc/cortex/overrides.yaml',
 
       // Persist ring tokens so that when the store-gateway will be restarted
       // it will pick the same tokens


### PR DESCRIPTION
**What this PR does**:
The flag `-limits.per-user-override-config` will be removed in Cortex 1.9 (RC is already out), so in this PR I'm replacing it with the new `-runtime-config.file`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
