### PR TITLE
Changed alertmanager config to use the new storage config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [CHANGE] Replaced the deprecated CLI flag `-limits.per-user-override-config` (removed in Cortex 1.9) with `-runtime-config.file`. #304
 * [CHANGE] Ruler: changed ruler config to use the new storage config. #306
 * [CHANGE] Ruler: enabled API response compression. #306
+* [CHANGE] Alertmanager: changed alertmanager config to use the new storage config. #307
 * [FEATURE] Added "Cortex / Rollout progress" dashboard. #289 #290
 * [FEATURE] Added support for using query-scheduler component, which moves the queue out of query-frontend, and allows scaling up of query-frontend component. #295
 * [ENHANCEMENT] Added `newCompactorStatefulSet()` function to create a custom statefulset for the compactor. #287

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -253,9 +253,8 @@
     },
 
     ruler_enabled: false,
-    ruler_client_type: error 'you must specify a storage backend type for the ruler (azure, configdb, gcs, s3, local)',
-    // TODO: Generic client generating functions would be nice.
-    ruler_s3_bucket_name: $._config.s3_bucket_name,
+    ruler_client_type: error 'you must specify a storage backend type for the ruler (azure, gcs, s3, local)',
+    ruler_s3_bucket_name: error 'you must specify the ruler S3 bucket name',
     ruler_gcs_bucket_name: error 'must specify a GCS bucket name',
 
     rulerClientConfig:
@@ -263,9 +262,6 @@
         'ruler-storage.backend': $._config.ruler_client_type,
       } +
       {
-        configdb: {
-          configs_api_url: 'config.%s.svc.cluster.local' % $._config.namespace,
-        },
         gcs: {
           'ruler-storage.gcs.bucket-name': $._config.ruler_gcs_bucket_name,
         },
@@ -284,26 +280,24 @@
       fallback_config: {},
     },
 
-    alertmanager_client_type: error 'you must specify a storage backend type for the alertmanager (azure, configdb, gcs, s3, local)',
-    alertmanager_s3_bucket_name: $._config.s3_bucket_name,
+    alertmanager_client_type: error 'you must specify a storage backend type for the alertmanager (azure, gcs, s3, local)',
+    alertmanager_s3_bucket_name: error 'you must specify the alertmanager S3 bucket name',
     alertmanager_gcs_bucket_name: error 'must specify a GCS bucket name',
 
     alertmanagerStorageClientConfig:
       {
-        'alertmanager.storage.type': $._config.alertmanager_client_type,
+        'alertmanager-storage.backend': $._config.alertmanager_client_type,
       } +
       {
-        configdb: {
-          configs_api_url: 'config.%s.svc.cluster.local' % $._config.namespace,
-        },
         gcs: {
-          'alertmanager.storage.gcs.bucketname': $._config.alertmanager_gcs_bucket_name,
+          'alertmanager-storage.gcs.bucket-name': $._config.alertmanager_gcs_bucket_name,
         },
         s3: {
-          'alertmanager.storage.s3.url': 'https://%s/%s' % [$._config.aws_region, $._config.alertmanager_s3_bucket_name],
+          'alertmanager-storage.s3.region': $._config.aws_region,
+          'alertmanager-storage.s3.bucket-name': $._config.alertmanager_s3_bucket_name,
         },
         'local': {
-          'alertmanager.storage.local.directory': $._config.alertmanager_local_directory,
+          'alertmanager-storage.local.path': $._config.alertmanager_local_directory,
         },
       }[$._config.alertmanager_client_type],
 


### PR DESCRIPTION
**What this PR does**:
Similarly to https://github.com/grafana/cortex-jsonnet/pull/306, in this PR I'm switching the ruler to use the new storage config. I'm also taking the opportunity to do a couple of other changes:

1. Remove configdb support from ruler and alertmanager: wasn't working even before, so I guess none was using it
2. Do not auto-configure `alertmanager_s3_bucket_name` and `ruler_s3_bucket_name` (like we already do for GCS)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
