### PR TITLE
Only show namespaces from selected cluster. "All" works thanks to using regex matcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [CHANGE] `namespace` template variable in dashboards now only selects namespaces for selected clusters. #311
+
 ## 1.9.0 / 2021-05-18
 
 * [CHANGE] Replace use of removed Cortex CLI flag `-querier.compress-http-responses` for query frontend with `-api.response-compression-enabled`. #299

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -36,13 +36,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           then d.addMultiTemplate('job', 'cortex_build_info', 'job')
           else d
                .addMultiTemplate('cluster', 'cortex_build_info', 'cluster')
-               .addMultiTemplate('namespace', 'cortex_build_info', 'namespace')
+               .addMultiTemplate('namespace', 'cortex_build_info{cluster=~"$cluster"}', 'namespace')
         else
           if $._config.singleBinary
           then d.addTemplate('job', 'cortex_build_info', 'job')
           else d
                .addTemplate('cluster', 'cortex_build_info', 'cluster')
-               .addTemplate('namespace', 'cortex_build_info', 'namespace'),
+               .addTemplate('namespace', 'cortex_build_info{cluster=~"$cluster"}', 'namespace'),
 
     },
 


### PR DESCRIPTION
**What this PR does**: This PR modifies `namespace` template variable to only show namespaces from selected cluster(s). This helps to navigate to correct namespace when having many of them.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
