### PR TITLE
Fixed CortexIngesterHasNotShippedBlocks alert false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] `namespace` template variable in dashboards now only selects namespaces for selected clusters. #311
+* [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 
 ## 1.9.0 / 2021-05-18
 


### PR DESCRIPTION
**What this PR does**:
We just got the `CortexIngesterHasNotShippedBlocks` alert firing because of an edge case.

We got a new cluster with shuffle-sharding enabled and so not all ingesters are receiving samples (not yet). This is the timeline that happened for a specific ingester:

- 2 days ago: ingester was ingesting samples of tenant X
- 1 day ago: ingester replicas scale up, tenant X resharded, the ingester is not receiving any samples at this point
- today: a new tenant Y begins remote writing, the ingester gets some samples

As soon as the tenant Y remotes writing, `thanos_objstore_bucket_last_successful_upload_time` is `> 0` because set to the last tenant X block shipped 1 day ago, `rate(cortex_ingester_ingested_samples_total[4h]))` is `> 0` because we're currently getting some samples from tenant Y but the 1st tenant Y block will be shipped within the next 4h, so we shouldn't trigger the alert immediately.

To solve this edge case, I'm proposing to also check if we were ingesting samples 4h.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
