### PR TITLE
Add playbooks linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:66e3a52
+      - image: grafana/cortex-jsonnet-build-image:1d5cd33
     steps:
       - checkout
       - run: make lint
@@ -19,7 +19,7 @@ jobs:
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:66e3a52
+      - image: grafana/cortex-jsonnet-build-image:1d5cd33
     steps:
       - checkout
       - run: make build-mixin
@@ -28,7 +28,7 @@ jobs:
 
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:66e3a52
+      - image: grafana/cortex-jsonnet-build-image:1d5cd33
     steps:
       - checkout
       - run: make test-readme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:1d5cd33
+      - image: grafana/cortex-jsonnet-build-image:c01038e
     steps:
       - checkout
       - run: make lint
@@ -19,7 +19,7 @@ jobs:
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:1d5cd33
+      - image: grafana/cortex-jsonnet-build-image:c01038e
     steps:
       - checkout
       - run: make build-mixin
@@ -28,7 +28,7 @@ jobs:
 
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:1d5cd33
+      - image: grafana/cortex-jsonnet-build-image:c01038e
     steps:
       - checkout
       - run: make test-readme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:c01038e
+      - image: grafana/cortex-jsonnet-build-image:e12c1b0
     steps:
       - checkout
       - run: make lint
@@ -19,7 +19,7 @@ jobs:
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:c01038e
+      - image: grafana/cortex-jsonnet-build-image:e12c1b0
     steps:
       - checkout
       - run: make build-mixin
@@ -28,7 +28,7 @@ jobs:
 
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:c01038e
+      - image: grafana/cortex-jsonnet-build-image:e12c1b0
     steps:
       - checkout
       - run: make test-readme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:e12c1b0
+      - image: grafana/cortex-jsonnet-build-image:e19ece2
     steps:
       - checkout
       - run: make lint
@@ -19,7 +19,7 @@ jobs:
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:e12c1b0
+      - image: grafana/cortex-jsonnet-build-image:e19ece2
     steps:
       - checkout
       - run: make build-mixin
@@ -28,7 +28,7 @@ jobs:
 
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:e12c1b0
+      - image: grafana/cortex-jsonnet-build-image:e19ece2
     steps:
       - checkout
       - run: make test-readme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,22 +11,24 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:8ce0de1
+      - image: grafana/cortex-jsonnet-build-image:66e3a52
     steps:
       - checkout
       - run: make lint
+      - run: make lint-playbooks
 
   build:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:8ce0de1
+      - image: grafana/cortex-jsonnet-build-image:66e3a52
     steps:
       - checkout
       - run: make build-mixin
       - store_artifacts:
           path: cortex-mixin/cortex-mixin.zip
+
   test-readme:
     docker:
-      - image: grafana/cortex-jsonnet-build-image:8ce0de1
+      - image: grafana/cortex-jsonnet-build-image:66e3a52
     steps:
       - checkout
       - run: make test-readme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,12 @@ jobs:
       - image: grafana/cortex-jsonnet-build-image:e19ece2
     steps:
       - checkout
-      - run: make lint
-      - run: make lint-playbooks
+      - run:
+          name: "Lint mixin"
+          command: make lint-mixin
+      - run:
+          name: "Lint playbooks"
+          command: make lint-playbooks
 
   build:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ build-mixin:
 	jb install && \
 	mixtool generate all --output-alerts out/alerts.yaml --output-rules out/rules.yaml --directory out/dashboards mixin.libsonnet && \
 	zip -q -r cortex-mixin.zip out
-	# TODO debug
-	cat cortex-mixin/out/alerts.yaml
 
 test-readme:
 	rm -rf test-readme && \

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ build-image:
 publish-build-image:
 	docker push grafana/cortex-jsonnet-build-image:$(shell git rev-parse --short HEAD)
 
-compile-mixin:
-
 build-mixin:
 	@cd cortex-mixin && \
 	rm -rf out && mkdir out && \

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,19 @@
 
 JSONNET_FMT := jsonnetfmt
 
-lint: lint-mixin
+lint: lint-mixin lint-playbooks
+
+lint-mixin: lint-mixin-with-mixtool lint-mixin-with-jsonnetfmt
+
+lint-mixin-with-jsonnetfmt:
 	@RESULT=0; \
 	for f in $$(find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print); do \
 		$(JSONNET_FMT) -- "$$f" | diff -u "$$f" -; \
 		RESULT=$$(($$RESULT + $$?)); \
 	done; \
-	RESULT=$$(($$RESULT + $$?)); \
+	exit $$RESULT
 
-lint-mixin:
+lint-mixin-with-mixtool:
 	cd cortex-mixin && \
 	jb install && \
 	mixtool lint mixin.libsonnet

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ lint-mixin:
 	jb install && \
 	mixtool lint mixin.libsonnet
 
+lint-playbooks: build-mixin
+	@./scripts/lint-playbooks.sh
+
 fmt:
 	@find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
 		xargs -n 1 -- $(JSONNET_FMT) -i
@@ -25,12 +28,14 @@ build-image:
 publish-build-image:
 	docker push grafana/cortex-jsonnet-build-image:$(shell git rev-parse --short HEAD)
 
+compile-mixin:
+
 build-mixin:
 	cd cortex-mixin && \
 	rm -rf out && mkdir out && \
 	jb install && \
 	mixtool generate all --output-alerts out/alerts.yaml --output-rules out/rules.yaml --directory out/dashboards mixin.libsonnet && \
-	zip -r cortex-mixin.zip out
+	zip -q -r cortex-mixin.zip out
 
 test-readme:
 	rm -rf test-readme && \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ build-mixin:
 	mixtool generate all --output-alerts out/alerts.yaml --output-rules out/rules.yaml --directory out/dashboards mixin.libsonnet && \
 	zip -q -r cortex-mixin.zip out
 	# TODO debug
-	cat out/alerts.yaml
 	cat cortex-mixin/out/alerts.yaml
 
 test-readme:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ build-mixin:
 	jb install && \
 	mixtool generate all --output-alerts out/alerts.yaml --output-rules out/rules.yaml --directory out/dashboards mixin.libsonnet && \
 	zip -q -r cortex-mixin.zip out
+	# TODO debug
+	cat out/alerts.yaml
+	cat cortex-mixin/out/alerts.yaml
 
 test-readme:
 	rm -rf test-readme && \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ publish-build-image:
 compile-mixin:
 
 build-mixin:
-	cd cortex-mixin && \
+	@cd cortex-mixin && \
 	rm -rf out && mkdir out && \
 	jb install && \
 	mixtool generate all --output-alerts out/alerts.yaml --output-rules out/rules.yaml --directory out/dashboards mixin.libsonnet && \

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,5 +1,5 @@
 # Build jsonnet
-FROM alpine:edge AS jsonnet-builder
+FROM alpine:3.13 AS jsonnet-builder
 RUN apk add --no-cache git make g++
 RUN git clone https://github.com/google/jsonnet && \
     git  -C jsonnet checkout v0.15.0 && \
@@ -8,7 +8,7 @@ RUN git clone https://github.com/google/jsonnet && \
     cp jsonnet/jsonnetfmt /usr/bin
 
 # Build jb
-FROM alpine:edge AS jb-builder
+FROM alpine:3.13 AS jb-builder
 ARG JSONNET_BUNDLER_VERSION=0.4.0
 ARG JSONNET_BUNDLER_CHECKSUM="433edab5554a88a0371e11e93080408b225d41c31decf321c02b50d2e44993ce  /usr/bin/jb"
 RUN apk add --no-cache curl
@@ -17,7 +17,7 @@ RUN echo "${JSONNET_BUNDLER_CHECKSUM}" | sha256sum -c || (printf "wanted: %s\n  
 RUN chmod +x /usr/bin/jb
 
 # Build tanka
-FROM alpine:edge AS tk-builder
+FROM alpine:3.13 AS tk-builder
 ARG TANKA_VERSION=0.11.1
 ARG TANKA_CHECKSUM="3b253ca7d7bf01189604c10a8f7cead20a553ddc04c813f0f836d80338cfad71  /usr/bin/tk"
 RUN apk add --no-cache curl
@@ -29,11 +29,15 @@ RUN chmod +x /usr/bin/tk
 FROM golang:1.15-alpine AS mixtool-builder
 RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@59d44357240d
 
-# TODO Switch to alpine:3.14 once released. Previous versions don't package yq v4.
-FROM alpine:edge
-RUN apk add --no-cache git make libgcc libstdc++ zip yq
+FROM alpine:3.13
+RUN apk add --no-cache git make libgcc libstdc++ zip
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin
 COPY --from=jb-builder /usr/bin/jb /usr/bin
 COPY --from=tk-builder /usr/bin/tk /usr/bin
 COPY --from=mixtool-builder /go/bin/mixtool /usr/bin
+
+# Install yq.
+# TODO We can install it via apk once alpine 3.14 or above will be released. Previous versions don't package v4.
+RUN wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.9.3/yq_linux_amd64 && \
+    chmod +x /usr/bin/yq

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod +x /usr/bin/tk
 
 # Build mixtool
 FROM golang:1.15-alpine AS mixtool-builder
-RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@59d44357240d
+RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@ae18e31161ea10545b9c1ac0d23c10122f2c12b5
 
 FROM alpine:3.13
 RUN apk add --no-cache git make libgcc libstdc++ zip

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,5 +1,5 @@
 # Build jsonnet
-FROM alpine:3.13 AS jsonnet-builder
+FROM alpine:edge AS jsonnet-builder
 RUN apk add --no-cache git make g++
 RUN git clone https://github.com/google/jsonnet && \
     git  -C jsonnet checkout v0.15.0 && \
@@ -8,7 +8,7 @@ RUN git clone https://github.com/google/jsonnet && \
     cp jsonnet/jsonnetfmt /usr/bin
 
 # Build jb
-FROM alpine:3.13 AS jb-builder
+FROM alpine:edge AS jb-builder
 ARG JSONNET_BUNDLER_VERSION=0.4.0
 ARG JSONNET_BUNDLER_CHECKSUM="433edab5554a88a0371e11e93080408b225d41c31decf321c02b50d2e44993ce  /usr/bin/jb"
 RUN apk add --no-cache curl
@@ -17,7 +17,7 @@ RUN echo "${JSONNET_BUNDLER_CHECKSUM}" | sha256sum -c || (printf "wanted: %s\n  
 RUN chmod +x /usr/bin/jb
 
 # Build tanka
-FROM alpine:3.13 AS tk-builder
+FROM alpine:edge AS tk-builder
 ARG TANKA_VERSION=0.11.1
 ARG TANKA_CHECKSUM="3b253ca7d7bf01189604c10a8f7cead20a553ddc04c813f0f836d80338cfad71  /usr/bin/tk"
 RUN apk add --no-cache curl
@@ -29,7 +29,8 @@ RUN chmod +x /usr/bin/tk
 FROM golang:1.15-alpine AS mixtool-builder
 RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@59d44357240d
 
-FROM alpine:3.13
+# TODO Switch to alpine:3.14 once released. Previous versions don't package yq v4.
+FROM alpine:edge
 RUN apk add --no-cache git make libgcc libstdc++ zip yq
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,5 +1,5 @@
 # Build jsonnet
-FROM alpine:3.11 AS jsonnet-builder
+FROM alpine:3.13 AS jsonnet-builder
 RUN apk add --no-cache git make g++
 RUN git clone https://github.com/google/jsonnet && \
     git  -C jsonnet checkout v0.15.0 && \
@@ -8,7 +8,7 @@ RUN git clone https://github.com/google/jsonnet && \
     cp jsonnet/jsonnetfmt /usr/bin
 
 # Build jb
-FROM alpine:3.11 AS jb-builder
+FROM alpine:3.13 AS jb-builder
 ARG JSONNET_BUNDLER_VERSION=0.4.0
 ARG JSONNET_BUNDLER_CHECKSUM="433edab5554a88a0371e11e93080408b225d41c31decf321c02b50d2e44993ce  /usr/bin/jb"
 RUN apk add --no-cache curl
@@ -17,7 +17,7 @@ RUN echo "${JSONNET_BUNDLER_CHECKSUM}" | sha256sum -c || (printf "wanted: %s\n  
 RUN chmod +x /usr/bin/jb
 
 # Build tanka
-FROM alpine:3.11 AS tk-builder
+FROM alpine:3.13 AS tk-builder
 ARG TANKA_VERSION=0.11.1
 ARG TANKA_CHECKSUM="3b253ca7d7bf01189604c10a8f7cead20a553ddc04c813f0f836d80338cfad71  /usr/bin/tk"
 RUN apk add --no-cache curl
@@ -29,8 +29,8 @@ RUN chmod +x /usr/bin/tk
 FROM golang:1.15-alpine AS mixtool-builder
 RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@59d44357240d
 
-FROM alpine:3.11
-RUN apk add --no-cache git make libgcc libstdc++ zip
+FROM alpine:3.13
+RUN apk add --no-cache git make libgcc libstdc++ zip yq
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin
 COPY --from=jb-builder /usr/bin/jb /usr/bin

--- a/cortex-mixin/dashboards/scaling.libsonnet
+++ b/cortex-mixin/dashboards/scaling.libsonnet
@@ -48,12 +48,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
             )
           |||,
         ], {
-          '__name__': { alias: 'Cluster', type: 'hidden' },
+          __name__: { alias: 'Cluster', type: 'hidden' },
           cluster: { alias: 'Cluster' },
           namespace: { alias: 'Namespace' },
           deployment: { alias: 'Service' },
           reason: { alias: 'Reason' },
-          'Value': { alias: 'Required Replicas', decimals: 0 },
+          Value: { alias: 'Required Replicas', decimals: 0 },
         })
       )
     ),

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -24,7 +24,15 @@ If nothing obvious from the above, check for increased load:
 - If there is an increase in the number of active series and the memory provisioned is not enough, scale up the ingesters horizontally to have the same number of series as before per ingester.
 - If we had an outage and once Cortex is back up, the incoming traffic increases. (or) The clients have their Prometheus remote-write lagging and starts to send samples at a higher rate (again, an increase in traffic but in terms of number of samples). Scale up the ingester horizontally in this case too.
 
-### CortexRequest Latency
+### CortexIngesterReachingSeriesLimit
+
+_TODO: this playbook has not been written yet._
+
+### CortexIngesterReachingTenantsLimit
+
+_TODO: this playbook has not been written yet._
+
+### CortexRequestLatency
 First establish if the alert is for read or write latency. The alert should say.
 
 #### Write Latency
@@ -47,6 +55,10 @@ If you think its provisioning / scaling is the problem, consult the scaling dash
 
 Right now most of the execution time will be spent in PromQL's innerEval. NB that the prepare (index and chunk fetch) are now interleaved with Eval, so you need to expand both to confirm if its flow execution of slow fetching.
 
+### CortexRequestErrors
+
+_TODO: this playbook has not been written yet._
+
 ### CortexTransferFailed
 This alert goes off when an ingester fails to find another node to transfer its data to when it was shutting down. If there is both a pod stuck terminating and one stuck joining, look at the kubernetes events. This may be due to scheduling problems caused by some combination of anti affinity rules/resource utilization. Adding a new node can help in these circumstances. You can see recent events associated with a resource via kubectl describe, ex: `kubectl -n <namespace> describe pod <pod>`
 
@@ -68,6 +80,14 @@ More information:
 ### CortexRulerFailedRingCheck
 
 This alert occurs when a ruler is unable to validate whether or not it should claim ownership over the evaluation of a rule group. The most likely cause is that one of the rule ring entries is unhealthy. If this is the case proceed to the ring admin http page and forget the unhealth ruler. The other possible cause would be an error returned the ring client. If this is the case look into debugging the ring based on the in-use backend implementation.
+
+### CortexRulerFailedEvaluations
+
+_TODO: this playbook has not been written yet._
+
+### CortexRulerMissedEvaluations
+
+_TODO: this playbook has not been written yet._
 
 ### CortexIngesterHasNotShippedBlocks
 
@@ -233,6 +253,14 @@ gsutil mv gs://BUCKET/TENANT/BLOCK gs://BUCKET/TENANT/corrupted-BLOCK
 
 Same as [`CortexCompactorHasNotUploadedBlocks`](#CortexCompactorHasNotUploadedBlocks).
 
+### CortexCompactorHasNotSuccessfullyRunCompaction
+
+_TODO: this playbook has not been written yet._
+
+### CortexCompactorRunFailed
+
+_TODO: this playbook has not been written yet._
+
 ### CortexBucketIndexNotUpdated
 
 This alert fires when the bucket index, for a given tenant, is not updated since a long time. The bucket index is expected to be periodically updated by the compactor and is used by queriers and store-gateways to get an almost-updated view over the bucket store. 
@@ -276,6 +304,74 @@ WAL corruptions are only detected at startups, so at this point the WAL/Checkpoi
   1. Less than the quorum number for your replication factor: No data loss, because there is a guarantee that the data is replicated. For example, if replication factor is 3, then it's fine if corruption was on 1 ingester.
   2. Equal or more than the quorum number but less than replication factor: There is a good chance that there is no data loss if it was replicated to desired number of ingesters. But it's good to check once for data loss.
   3. Equal or more than the replication factor: Then there is definitely some data loss.
+
+### CortexRequestErrors
+
+_TODO: this playbook has not been written yet._
+
+### CortexTableSyncFailure
+
+_TODO: this playbook has not been written yet._
+
+### CortexQueriesIncorrect
+
+_TODO: this playbook has not been written yet._
+
+### CortexInconsistentConfig
+
+_TODO: this playbook has not been written yet._
+
+### CortexBadRuntimeConfig
+
+_TODO: this playbook has not been written yet._
+
+### CortexQuerierCapacityFull
+
+_TODO: this playbook has not been written yet._
+
+### CortexFrontendQueriesStuck
+
+_TODO: this playbook has not been written yet._
+
+### CortexSchedulerQueriesStuck
+
+_TODO: this playbook has not been written yet._
+
+### CortexCacheRequestErrors
+
+_TODO: this playbook has not been written yet._
+
+### CortexOldChunkInMemory
+
+_TODO: this playbook has not been written yet._
+
+### CortexCheckpointCreationFailed
+
+_TODO: this playbook has not been written yet._
+
+### CortexCheckpointDeletionFailed
+
+_TODO: this playbook has not been written yet._
+
+### CortexProvisioningMemcachedTooSmall
+
+_TODO: this playbook has not been written yet._
+
+### CortexProvisioningTooManyActiveSeries
+
+_TODO: this playbook has not been written yet._
+
+### CortexProvisioningTooManyWrites
+
+_TODO: this playbook has not been written yet._
+
+### CortexAllocatingTooMuchMemory
+
+_TODO: this playbook has not been written yet._
+
+### CortexGossipMembersMismatch
+
+_TODO: this playbook has not been written yet._
 
 ### EtcdAllocatingTooMuchMemory
 

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 SCRIPT_DIR=$(realpath $(dirname $0))
 
+# TODO debug
+echo ${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml
+cat ${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml
+
 # List all alerts.
 ALERTS=$(yq eval '.groups.[].rules.[].alert' "${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml" 2> /dev/stdout)
 if [ $? -ne 0 ]; then

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -9,7 +9,7 @@ if [ $? -ne 0 ]; then
   exit 1
 elif [ -z "$ALERTS" ]; then
   echo "No alerts found. Something went wrong with the listing."
-  echo 1
+  exit 1
 fi
 
 # Check if each alert is referenced in the playbooks.

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -16,7 +16,7 @@ fi
 STATUS=0
 
 for ALERT in $ALERTS; do
-  grep --quiet "$ALERT" "${SCRIPT_DIR}/../cortex-mixin/docs/playbooks.md"
+  grep -q "$ALERT" "${SCRIPT_DIR}/../cortex-mixin/docs/playbooks.md"
   if [ $? -ne 0 ]; then
     echo "Missing playbook for: $ALERT"
     STATUS=1

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 SCRIPT_DIR=$(realpath $(dirname $0))
 
-# TODO debug
-echo ${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml
-cat ${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml
-
 # List all alerts.
 ALERTS=$(yq eval '.groups.[].rules.[].alert' "${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml" 2> /dev/stdout)
 if [ $? -ne 0 ]; then

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -16,8 +16,7 @@ fi
 STATUS=0
 
 for ALERT in $ALERTS; do
-  grep -q "$ALERT" "${SCRIPT_DIR}/../cortex-mixin/docs/playbooks.md"
-  if [ $? -ne 0 ]; then
+  if ! grep -q "${ALERT}$" "${SCRIPT_DIR}/../cortex-mixin/docs/playbooks.md"; then
     echo "Missing playbook for: $ALERT"
     STATUS=1
   fi

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+SCRIPT_DIR=$(realpath $(dirname $0))
+
+# List all alerts.
+ALERTS=$(yq eval '.groups.[].rules.[].alert' "${SCRIPT_DIR}/../cortex-mixin/out/alerts.yaml" 2> /dev/stdout)
+if [ $? -ne 0 ]; then
+  echo "Unable to list alerts. Got output:"
+  echo "$ALERTS"
+  exit 1
+fi
+
+# Check if each alert is referenced in the playbooks.
+STATUS=0
+
+for ALERT in $ALERTS; do
+  grep --quiet "$ALERT" "${SCRIPT_DIR}/../cortex-mixin/docs/playbooks.md"
+  if [ $? -ne 0 ]; then
+    echo "Missing playbook for: $ALERT"
+    STATUS=1
+  fi
+done
+
+exit $STATUS

--- a/scripts/lint-playbooks.sh
+++ b/scripts/lint-playbooks.sh
@@ -7,6 +7,9 @@ if [ $? -ne 0 ]; then
   echo "Unable to list alerts. Got output:"
   echo "$ALERTS"
   exit 1
+elif [ -z "$ALERTS" ]; then
+  echo "No alerts found. Something went wrong with the listing."
+  echo 1
 fi
 
 # Check if each alert is referenced in the playbooks.


### PR DESCRIPTION
**What this PR does**:
In this PR I'm adding a linter to check if each alert is referenced in playbooks. Since we have several alerts without a playbook, I've temporarily added them to `playbooks.md` to let the linter pass (and will progressively address them in follow up PRs). However, the new linter will enforce that any new alert will have the playbook too starting from now.

Example of failed playbooks linter:
https://app.circleci.com/pipelines/github/grafana/cortex-jsonnet/852/workflows/8932fcad-3009-45e7-9124-1427816cb319/jobs/2115

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
