### PR TITLE
Mount overrides configmap to alertmanager too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master / unreleased
 
 * [CHANGE] `namespace` template variable in dashboards now only selects namespaces for selected clusters. #311
+* [CHANGE] Alertmanager: mounted overrides configmap to alertmanager too. #315
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 
 ## 1.9.0 / 2021-05-18

--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -22,6 +22,7 @@
     {
       target: 'alertmanager',
       'log.level': 'debug',
+      'runtime-config.file': '/etc/cortex/overrides.yaml',
       'experimental.alertmanager.enable-api': 'true',
       'alertmanager.storage.path': '/data',
       'alertmanager.web.external-url': '%s/alertmanager' % $._config.external_url,
@@ -87,6 +88,7 @@
       statefulSet.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
       statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
       statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
+      $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
       statefulSet.mixin.spec.template.spec.withVolumesMixin(
         if hasFallbackConfig then
           [volume.fromConfigMap('alertmanager-fallback-config', 'alertmanager-fallback-config')]


### PR DESCRIPTION
**What this PR does**:
The Cortex Alertmanager now supports per-tenant overrides, so we should mount the overrides configmap to Alertmanager too.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
