### PR TITLE
Upgrade memcached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] `namespace` template variable in dashboards now only selects namespaces for selected clusters. #311
 * [CHANGE] Alertmanager: mounted overrides configmap to alertmanager too. #315
+* [CHANGE] Memcached: upgraded memcached from `1.5.17` to `1.6.9`. #316
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 
 ## 1.9.0 / 2021-05-18

--- a/cortex/images.libsonnet
+++ b/cortex/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.5.17-alpine',
+    memcached: 'memcached:1.6.9-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.6.0',
 
     // Our services.


### PR DESCRIPTION
**What this PR does**:
We're running memcached `1.6.9` in production since few weeks and looks good. I would like to upgrade it in the OSS mixin too.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
