### PR TITLE
refactor: Dashboards: add functions to reduce code duplication; make more use of _config

### DIFF
--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -49,6 +49,12 @@
     // The label used to differentiate between different application instances (i.e. 'pod' in a kubernetes install).
     per_instance_label: 'pod',
 
+    // Name selectors for different application instances, using the "per_instance_label".
+    instance_names: {
+      compactor: 'compactor.*',
+      alertmanager: 'alertmanager.*',
+    },
+
     // The label used to differentiate between different nodes (i.e. servers).
     per_node_label: 'instance',
   },

--- a/cortex-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager-resources.libsonnet
@@ -43,16 +43,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Network')
       .addPanel(
-        $.panel('Receive Bandwidth') +
-        $.queryPanel('sum by(pod) (rate(container_network_receive_bytes_total{%s,pod=~"alertmanager.*"}[$__rate_interval]))' % $.namespaceMatcher(), '{{pod}}') +
-        $.stack +
-        { yaxes: $.yaxes('Bps') },
+        $.containerNetworkReceiveBytesPanel($._config.instance_names.alertmanager),
       )
       .addPanel(
-        $.panel('Transmit Bandwidth') +
-        $.queryPanel('sum by(pod) (rate(container_network_transmit_bytes_total{%s,pod=~"alertmanager.*"}[$__rate_interval]))' % $.namespaceMatcher(), '{{pod}}') +
-        $.stack +
-        { yaxes: $.yaxes('Bps') },
+        $.containerNetworkTransmitBytesPanel($._config.instance_names.alertmanager),
       )
     )
     .addRow(

--- a/cortex-mixin/dashboards/compactor-resources.libsonnet
+++ b/cortex-mixin/dashboards/compactor-resources.libsonnet
@@ -19,16 +19,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Network')
       .addPanel(
-        $.panel('Receive Bandwidth') +
-        $.queryPanel('sum by(pod) (rate(container_network_receive_bytes_total{%s,pod=~"compactor.*"}[$__rate_interval]))' % $.namespaceMatcher(), '{{pod}}') +
-        $.stack +
-        { yaxes: $.yaxes('Bps') },
+        $.containerNetworkReceiveBytesPanel($._config.instance_names.compactor),
       )
       .addPanel(
-        $.panel('Transmit Bandwidth') +
-        $.queryPanel('sum by(pod) (rate(container_network_transmit_bytes_total{%s,pod=~"compactor.*"}[$__rate_interval]))' % $.namespaceMatcher(), '{{pod}}') +
-        $.stack +
-        { yaxes: $.yaxes('Bps') },
+        $.containerNetworkTransmitBytesPanel($._config.instance_names.compactor),
       )
     )
     .addRow(

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -128,9 +128,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerCPUUsagePanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([
-      'sum by(pod) (rate(container_cpu_usage_seconds_total{%s,container="%s"}[$__rate_interval]))' % [$.namespaceMatcher(), containerName],
+      'sum by(%s) (rate(container_cpu_usage_seconds_total{%s,container="%s"}[$__rate_interval]))' % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
       'min(container_spec_cpu_quota{%s,container="%s"} / container_spec_cpu_period{%s,container="%s"})' % [$.namespaceMatcher(), containerName, $.namespaceMatcher(), containerName],
-    ], ['{{pod}}', 'limit']) +
+    ], ['{{%s}}' % $._config.per_instance_label, 'limit']) +
     {
       seriesOverrides: [
         {
@@ -146,10 +146,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     $.panel(title) +
     $.queryPanel([
       // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
-      // summing the memory of the old pod (whose metric will be stale for 5m) to the new pod.
-      'max by(pod) (container_memory_working_set_bytes{%s,container="%s"})' % [$.namespaceMatcher(), containerName],
+      // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
+      'max by(%s) (container_memory_working_set_bytes{%s,container="%s"})' % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
       'min(container_spec_memory_limit_bytes{%s,container="%s"} > 0)' % [$.namespaceMatcher(), containerName],
-    ], ['{{pod}}', 'limit']) +
+    ], ['{{%s}}' % $._config.per_instance_label, 'limit']) +
     {
       seriesOverrides: [
         {
@@ -161,6 +161,24 @@ local utils = import 'mixin-utils/utils.libsonnet';
       yaxes: $.yaxes('bytes'),
       tooltip: { sort: 2 },  // Sort descending.
     },
+
+  containerNetworkPanel(title, metric, instanceName):: 
+    $.panel(title) +
+    $.queryPanel(
+      'sum by(%(instance)s) (rate(%(metric)s{%(namespace)s,%(instance)s=~"%(instanceName)s"}[$__rate_interval]))' % {
+        namespace: $.namespaceMatcher(), 
+        metric: metric,
+        instance: $._config.per_instance_label, 
+        instanceName: instanceName, 
+      }, '{{%s}}' % $._config.per_instance_label) +
+    $.stack +
+    { yaxes: $.yaxes('Bps') },
+
+  containerNetworkReceiveBytesPanel(instanceName)::
+    $.containerNetworkPanel('Receive Bandwidth', 'container_network_receive_bytes_total', instanceName),
+
+  containerNetworkTransmitBytesPanel(instanceName)::
+    $.containerNetworkPanel('Transmit Bandwidth', 'container_network_transmit_bytes_total', instanceName),
 
   goHeapInUsePanel(title, jobName)::
     $.panel(title) +

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -162,15 +162,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
       tooltip: { sort: 2 },  // Sort descending.
     },
 
-  containerNetworkPanel(title, metric, instanceName):: 
+  containerNetworkPanel(title, metric, instanceName)::
     $.panel(title) +
     $.queryPanel(
       'sum by(%(instance)s) (rate(%(metric)s{%(namespace)s,%(instance)s=~"%(instanceName)s"}[$__rate_interval]))' % {
-        namespace: $.namespaceMatcher(), 
+        namespace: $.namespaceMatcher(),
         metric: metric,
-        instance: $._config.per_instance_label, 
-        instanceName: instanceName, 
-      }, '{{%s}}' % $._config.per_instance_label) +
+        instance: $._config.per_instance_label,
+        instanceName: instanceName,
+      }, '{{%s}}' % $._config.per_instance_label
+    ) +
     $.stack +
     { yaxes: $.yaxes('Bps') },
 


### PR DESCRIPTION
**What this PR does**:

Minor refactoring to reduce code duplication and make it easier to override some of the "resources" dashborads.

In dashboards, and dashboard utils: 
  - Removed hardcoded "pod" strings from queries, and replaced with references to `$._config.per_instance_label`
  - Added `$._config.instance_names`, which correpond to the `per_instance_label` (instead of hardcoded strings)
  - Added functions for network panels, used by compactor and storegateway dashboards 

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
