### PR TITLE
refactor: config for job aggregation strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [CHANGE] Alertmanager: mounted overrides configmap to alertmanager too. #315
 * [CHANGE] Memcached: upgraded memcached from `1.5.17` to `1.6.9`. #316
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
+* [CHANGE] Dashboards: added overridable `job_labels` and `cluster_labels` to the configuration object as label lists to uniquely identify jobs and clusters in the metric names and group-by lists in dashboards. #319
+* [CHANGE] Dashboards: `alert_aggregation_labels` has been removed from the configuration and overriding this value has been deprecated. Instead the labels are now defined by the `cluster_labels` list, and should be overridden accordingly through that list. #319
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex-mixin/alerts.libsonnet
+++ b/cortex-mixin/alerts.libsonnet
@@ -8,5 +8,5 @@
        (import 'alerts/compactor.libsonnet')
      else {}) +
 
-    { _config:: $._config },
+    { _config:: $._config + $._group_config },
 }

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -39,7 +39,7 @@
         {
           alert: 'CortexRequestLatency',
           expr: |||
-            cluster_namespace_job_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop"}
+            %(job_aggregation_prefix)s_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop"}
                >
             %(cortex_p99_latency_threshold_seconds)s
           ||| % $._config,

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -39,7 +39,7 @@
         {
           alert: 'CortexRequestLatency',
           expr: |||
-            %(job_aggregation_prefix)s_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop"}
+            %(group_prefix_jobs)s_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop"}
                >
             %(cortex_p99_latency_threshold_seconds)s
           ||| % $._config,

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -38,6 +38,11 @@
       compactor: 'compactor.*',  // Match also custom compactor deployments.
     },
 
+    // Aggregation strings related to "jobs"
+    job_aggregation_prefix: 'cluster_namespace_job',
+    job_aggregation_labels_recording_rules: 'cluster, namespace, job',
+    job_aggregation_labels_active_series: 'namespace',
+
     // Labels used to in alert aggregations - should uniquely identify
     // a single Cortex cluster.
     alert_aggregation_labels: 'cluster, namespace',

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -38,14 +38,10 @@
       compactor: 'compactor.*',  // Match also custom compactor deployments.
     },
 
-    // Aggregation strings related to "jobs"
-    job_aggregation_prefix: 'cluster_namespace_job',
-    job_aggregation_labels_recording_rules: 'cluster, namespace, job',
-    job_aggregation_labels_active_series: 'namespace',
+    // Grouping labels, to uniquely identify and group by {jobs, clusters}
+    job_labels: ['cluster', 'namespace', 'job'],
+    cluster_labels: ['cluster', 'namespace'],
 
-    // Labels used to in alert aggregations - should uniquely identify
-    // a single Cortex cluster.
-    alert_aggregation_labels: 'cluster, namespace',
     cortex_p99_latency_threshold_seconds: 2.5,
 
     // Whether resources dashboards are enabled (based on cAdvisor metrics).

--- a/cortex-mixin/dashboards.libsonnet
+++ b/cortex-mixin/dashboards.libsonnet
@@ -31,5 +31,5 @@
        (import 'dashboards/writes-resources.libsonnet') +
        (import 'dashboards/alertmanager-resources.libsonnet')) +
 
-    { _config:: $._config },
+    { _config:: $._config + $._group_config },
 }

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -13,10 +13,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Samples / s') +
         $.statPanel(
-            'sum(%(jobAggregationPrefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % {
+          'sum(%(jobAggregationPrefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % {
             job: $.jobMatcher($._config.job_names.distributor),
-            jobAggregationPrefix: $._config.job_aggregation_prefix
-          }, 
+            jobAggregationPrefix: $._config.job_aggregation_prefix,
+          },
           format='reqps'
         )
       )
@@ -29,7 +29,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ||| % {
           ingester: $.jobMatcher($._config.job_names.ingester),
           distributor: $.jobMatcher($._config.job_names.distributor),
-          labels: $._config.job_aggregation_labels_active_series
+          labels: $._config.job_aggregation_labels_active_series,
         }, format='short')
       )
       .addPanel(

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -13,9 +13,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Samples / s') +
         $.statPanel(
-          'sum(%(jobAggregationPrefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % {
+          'sum(%(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % $._config + {
             job: $.jobMatcher($._config.job_names.distributor),
-            jobAggregationPrefix: $._config.job_aggregation_prefix,
           },
           format='reqps'
         )

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -13,9 +13,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Samples / s') +
         $.statPanel(
-          'sum(%(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % $._config + {
-            job: $.jobMatcher($._config.job_names.distributor),
-          },
+          'sum(%(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % (
+            $._config {
+              job: $.jobMatcher($._config.job_names.distributor),
+            }
+          ),
           format='reqps'
         )
       )

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -13,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.panel('Samples / s') +
         $.statPanel(
-          'sum(%(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m{%(job)s})' % (
+          'sum(%(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m{%(job)s})' % (
             $._config {
               job: $.jobMatcher($._config.job_names.distributor),
             }
@@ -25,12 +25,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Active Series') +
         $.statPanel(|||
           sum(cortex_ingester_memory_series{%(ingester)s}
-          / on(%(labels)s) group_left
-          max by (%(labels)s) (cortex_distributor_replication_factor{%(distributor)s}))
-        ||| % {
+          / on(%(group_by_cluster)s) group_left
+          max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s}))
+        ||| % ($._config) {
           ingester: $.jobMatcher($._config.job_names.ingester),
           distributor: $.jobMatcher($._config.job_names.distributor),
-          labels: $._config.job_aggregation_labels_active_series,
         }, format='short')
       )
       .addPanel(

--- a/cortex-mixin/groups.libsonnet
+++ b/cortex-mixin/groups.libsonnet
@@ -1,0 +1,45 @@
+{
+  local makePrefix(groups) = std.join('_', groups),
+  local makeGroupBy(groups) = std.join(', ', groups),
+
+  local group_by_cluster = makeGroupBy($._config.cluster_labels),
+
+  _group_config+:: {
+    // Each group prefix is composed of `_`-separated labels
+    group_prefix_jobs: makePrefix($._config.job_labels),
+    group_prefix_clusters: makePrefix($._config.cluster_labels),
+
+    // Each group-by label list is `, `-separated and unique identifies
+    group_by_job: makeGroupBy($._config.job_labels),
+    group_by_cluster: group_by_cluster,
+  },
+
+  // The following works around the deprecation of `$._config.alert_aggregation_labels`
+  // - If an override of that value is detected, a warning will be printed
+  // - If no override was detected, it will be set to the `group_by_cluster` value,
+  //   which will replace it altogether in the future.
+  local alert_aggregation_labels_override = (
+    {
+      alert_aggregation_labels: null,
+    } + super._config
+  ).alert_aggregation_labels,
+
+  _config+:: {
+    alert_aggregation_labels:
+      if alert_aggregation_labels_override != null
+      then std.trace(
+        |||
+          Deprecated: _config.alert_aggregation_labels 
+            This field has been explicitly overridden to "%s".
+            Instead, express the override in terms of _config.cluster_labels.
+              E.g., cluster_labels: %s will automatically convert to "%s".
+        ||| % [
+          alert_aggregation_labels_override,
+          $._config.cluster_labels,
+          group_by_cluster,
+        ],
+        alert_aggregation_labels_override
+      )
+      else std.trace('All good with group by cluster', group_by_cluster),
+  },
+}

--- a/cortex-mixin/groups.libsonnet
+++ b/cortex-mixin/groups.libsonnet
@@ -40,6 +40,6 @@
         ],
         alert_aggregation_labels_override
       )
-      group_by_cluster,
+      else group_by_cluster,
   },
 }

--- a/cortex-mixin/groups.libsonnet
+++ b/cortex-mixin/groups.libsonnet
@@ -40,6 +40,6 @@
         ],
         alert_aggregation_labels_override
       )
-      else std.trace('All good with group by cluster', group_by_cluster),
+      group_by_cluster,
   },
 }

--- a/cortex-mixin/mixin.libsonnet
+++ b/cortex-mixin/mixin.libsonnet
@@ -1,4 +1,5 @@
 (import 'config.libsonnet') +
+(import 'groups.libsonnet') +
 (import 'dashboards.libsonnet') +
 (import 'alerts.libsonnet') +
 (import 'recording_rules.libsonnet')

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -1,6 +1,12 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
 {
+  local _config = {
+    max_series_per_ingester: 1.5e6,
+    max_samples_per_sec_per_ingester: 80e3,
+    max_samples_per_sec_per_distributor: 240e3,
+    limit_utilisation_target: 0.6,
+  } + $._config + $._group_config,
   prometheusRules+:: {
     groups+: [
       {
@@ -51,21 +57,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         name: 'cortex_received_samples',
         rules: [
           {
-            record: '%(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m' % $._config,
+            record: '%(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m' % _config,
             expr: |||
-              sum by (%(job_aggregation_labels_recording_rules)s) (rate(cortex_distributor_received_samples_total[5m]))
-            ||| % $._config,
+              sum by (%(group_by_job)s) (rate(cortex_distributor_received_samples_total[5m]))
+            ||| % _config,
           },
         ],
       },
       {
-        local _config = {
-          max_series_per_ingester: 1.5e6,
-          max_samples_per_sec_per_ingester: 80e3,
-          max_samples_per_sec_per_distributor: 240e3,
-          limit_utilisation_target: 0.6,
-          job_aggregation_prefix: $._config.job_aggregation_prefix,
-        },
         name: 'cortex_scaling_rules',
         rules: [
           {
@@ -90,7 +89,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               ceil(
                 quantile_over_time(0.99,
                   sum by (cluster, namespace) (
-                    %(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m
+                    %(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m
                   )[24h:]
                 )
                 / %(max_samples_per_sec_per_distributor)s
@@ -124,7 +123,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               ceil(
                 quantile_over_time(0.99,
                   sum by (cluster, namespace) (
-                    %(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m
+                    %(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m
                   )[24h:]
                 )
                 * 3 / %(max_samples_per_sec_per_ingester)s

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -51,10 +51,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         name: 'cortex_received_samples',
         rules: [
           {
-            record: 'cluster_namespace_job:cortex_distributor_received_samples:rate5m',
+            record: '%(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m' % $._config,
             expr: |||
-              sum by (cluster, namespace, job) (rate(cortex_distributor_received_samples_total[5m]))
-            |||,
+              sum by (%(job_aggregation_labels_recording_rules)s) (rate(cortex_distributor_received_samples_total[5m]))
+            ||| % $._config,
           },
         ],
       },
@@ -64,6 +64,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           max_samples_per_sec_per_ingester: 80e3,
           max_samples_per_sec_per_distributor: 240e3,
           limit_utilisation_target: 0.6,
+          job_aggregation_prefix: $._config.job_aggregation_prefix,
         },
         name: 'cortex_scaling_rules',
         rules: [
@@ -89,7 +90,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               ceil(
                 quantile_over_time(0.99,
                   sum by (cluster, namespace) (
-                    cluster_namespace_job:cortex_distributor_received_samples:rate5m
+                    %(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m
                   )[24h:]
                 )
                 / %(max_samples_per_sec_per_distributor)s
@@ -123,7 +124,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               ceil(
                 quantile_over_time(0.99,
                   sum by (cluster, namespace) (
-                    cluster_namespace_job:cortex_distributor_received_samples:rate5m
+                    %(job_aggregation_prefix)s:cortex_distributor_received_samples:rate5m
                   )[24h:]
                 )
                 * 3 / %(max_samples_per_sec_per_ingester)s


### PR DESCRIPTION
**What this PR does**:
(Updated based on suggestions below)
- to make it easier to override, define "cluster_namespace_job" and "cluster, namespace, job" in terms of a new list in $._config: `job_labels: ['cluster', 'namespace', 'job']`
  - This replaces many hard-coded uses of these labels
- for consistency, based on feedback, we now follow a similar pattern for clusters:  `cluster_labels: ['cluster', 'namespace']`
- the resulting string values are defined using a new groups.libsonnet file as `$._group_config`, which gets mixed in where it is needed.
- a hard-coded group-by used `namespace` hard-coded in the query -- it has been updated to use the composition from `$._cluster_labels`. 
- deprecated `_config.alert_aggregation_labels`, since it is now a function of `$._cluster_labels`
  - there is a warning message if this old value is still being directly overridden; it still works (for now)
  - encouraged approach is to override the `cluster_labels` list instead, which is what will happen if `alert_aggregation_labels` is not overridden. 

The resulting output does not change (unless any of the new lists in config are overridden), except in exactly one case where it was recommended to replace a hard-coded reference from `namespace` to `cluster, namespace`, composed from `$._config.cluster_labels`.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
