### PR TITLE
feature: Add text boxes and descriptions to reads and writes dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [CHANGE] `namespace` template variable in dashboards now only selects namespaces for selected clusters. #311
+
 ## 1.9.0 / 2021-05-18
 
 * [CHANGE] Replace use of removed Cortex CLI flag `-querier.compress-http-responses` for query frontend with `-api.response-compression-enabled`. #299

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [CHANGE] Dashboards: added overridable `job_labels` and `cluster_labels` to the configuration object as label lists to uniquely identify jobs and clusters in the metric names and group-by lists in dashboards. #319
 * [CHANGE] Dashboards: `alert_aggregation_labels` has been removed from the configuration and overriding this value has been deprecated. Instead the labels are now defined by the `cluster_labels` list, and should be overridden accordingly through that list. #319
+* [ENHANCEMENT] Added documentation text panels and descriptions to Reads and Writes dashboards. 
 
 ## 1.9.0 / 2021-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [CHANGE] Dashboards: added overridable `job_labels` and `cluster_labels` to the configuration object as label lists to uniquely identify jobs and clusters in the metric names and group-by lists in dashboards. #319
 * [CHANGE] Dashboards: `alert_aggregation_labels` has been removed from the configuration and overriding this value has been deprecated. Instead the labels are now defined by the `cluster_labels` list, and should be overridden accordingly through that list. #319
-* [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. 
+* [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. #324
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -58,5 +58,11 @@
 
     // The label used to differentiate between different nodes (i.e. servers).
     per_node_label: 'instance',
+
+    // Whether certain dashboard description headers should be shown
+    show_dashboard_descriptions: {
+      writes: true,
+      reads: true,
+    },
   },
 }

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -103,6 +103,5 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.latencyPanel('cortex_compactor_meta_sync_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.compactor)),
       )
     )
-    .addRow($.objectStorePanels1('Object Store', 'compactor'))
-    .addRow($.objectStorePanels2('', 'compactor')),
+    .addRows($.getObjectStoreRows('Object Store', 'compactor')),
 }

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -18,7 +18,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panelDescription(
           'Per-instance runs',
           |||
-            Number of times a compactor instance triggers a compaction across all tenants its shard manage.
+            Number of times a compactor instance triggers a compaction across all tenants that it manages.
           |||
         ),
       )

--- a/cortex-mixin/dashboards/compactor.libsonnet
+++ b/cortex-mixin/dashboards/compactor.libsonnet
@@ -36,7 +36,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'Tenants compaction progress',
           |||
             In a multi-tenant cluster, display the progress of tenants that are compacted while compaction is running.
-            Reset to `0` after the compaction run is completed for all tenants in the shard.
+            Reset to <tt>0</tt> after the compaction run is completed for all tenants in the shard.
           |||
         ),
       )
@@ -50,7 +50,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panelDescription(
           'Compacted blocks / sec',
           |||
-            Display the amount of time that it’s taken to generate a single compacted block.
+            Rate of blocks that are generated as a result of a compaction operation.
           |||
         ),
       )
@@ -60,7 +60,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panelDescription(
           'Per-block compaction duration',
           |||
-            Rate of blocks that are generated as a result of a compaction operation.
+            Display the amount of time that it has taken to generate a single compacted block.
           |||
         ),
       )

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -14,6 +14,24 @@ local utils = import 'mixin-utils/utils.libsonnet';
         then self.addRow(row)
         else self,
 
+      addRowsIf(condition, rows)::
+        if condition
+        then
+          local reduceRows(dashboard, remainingRows) =
+            if (std.length(remainingRows) == 0)
+            then dashboard
+            else
+              reduceRows(
+                dashboard.addRow(remainingRows[0]),
+                std.slice(remainingRows, 1, std.length(remainingRows), 1)
+              )
+          ;
+          reduceRows(self, rows)
+        else self,
+
+      addRows(rows)::
+        addRowsIf(true, rows),
+
       addClusterSelectorTemplates(multi=true)::
         local d = self {
           tags: $._config.tags,
@@ -43,7 +61,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           else d
                .addTemplate('cluster', 'cortex_build_info', 'cluster')
                .addTemplate('namespace', 'cortex_build_info{cluster=~"$cluster"}', 'namespace'),
-
+      editable: true,
     },
 
   // The mixin allow specialism of the job selector depending on if its a single binary
@@ -274,8 +292,21 @@ local utils = import 'mixin-utils/utils.libsonnet';
     type: 'text',
   } + options,
 
-  objectStorePanels1(title, component)::
-    super.row(title)
+
+  getObjectStoreRows(title, component):: [
+    ($.row(title) { height: '25px' })
+    .addPanel(
+      $.textPanel(
+        '',
+        |||
+          - The panels below summarize the rate of requests issued by %s
+            to object storage, separated by operation type. 
+          - It also includes the average, median, and 99th percentile latency 
+            of each operation and the error rate of each operation. 
+        ||| % component
+      )
+    ),
+    $.row('')
     .addPanel(
       $.panel('Operations / sec') +
       $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s,component="%s"}[$__rate_interval]))' % [$.namespaceMatcher(), component], '{{operation}}') +
@@ -288,62 +319,163 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { yaxes: $.yaxes('percentunit') },
     )
     .addPanel(
-      $.panel('Op: Attributes') +
+      $.panel('Latency of Op: Attributes') +
       $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="%s",operation="attributes"}' % [$.namespaceMatcher(), component]),
     )
     .addPanel(
-      $.panel('Op: Exists') +
+      $.panel('Latency of Op: Exists') +
       $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="%s",operation="exists"}' % [$.namespaceMatcher(), component]),
     ),
-
-  // Second row of Object Store stats
-  objectStorePanels2(title, component)::
-    super.row(title)
+    $.row('')
     .addPanel(
-      $.panel('Op: Get') +
+      $.panel('Latency of Op: Get') +
       $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="%s",operation="get"}' % [$.namespaceMatcher(), component]),
     )
     .addPanel(
-      $.panel('Op: GetRange') +
+      $.panel('Latency of Op: GetRange') +
       $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="%s",operation="get_range"}' % [$.namespaceMatcher(), component]),
     )
     .addPanel(
-      $.panel('Op: Upload') +
+      $.panel('Latency of Op: Upload') +
       $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="%s",operation="upload"}' % [$.namespaceMatcher(), component]),
     )
     .addPanel(
-      $.panel('Op: Delete') +
+      $.panel('Latency of Op: Delete') +
       $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="%s",operation="delete"}' % [$.namespaceMatcher(), component]),
     ),
+  ],
 
   thanosMemcachedCache(title, jobName, component, cacheName)::
+    local config = {
+      jobMatcher: $.jobMatcher(jobName),
+      component: component,
+      cacheName: cacheName,
+      cacheNameReadable: std.strReplace(cacheName, '-', ' '),
+    };
+    local panelText = {
+      'metadata-cache':
+        |||
+          The metadata cache
+          is an optional component that the
+          store-gateway and querier
+          will check before going to object storage.
+          This set of panels focuses on the
+          %s’s use of the metadata cache.
+        ||| % component,
+      'chunks-cache':
+        |||
+          The chunks cache
+          is an optional component that the
+          store-gateway
+          will check before going to object storage.
+          This helps reduce calls to the object store.
+        |||,
+    }[cacheName];
+
     super.row(title)
     .addPanel(
+      $.textPanel(
+        '', panelText
+      )
+    )
+    .addPanel(
       $.panel('QPS') +
-      $.queryPanel('sum by(operation) (rate(thanos_memcached_operations_total{%s,component="%s",name="%s"}[$__rate_interval]))' % [$.jobMatcher(jobName), component, cacheName], '{{operation}}') +
+      $.queryPanel(
+        |||
+          sum by(operation) (
+            rate(
+              thanos_memcached_operations_total{
+                %(jobMatcher)s,
+                component="%(component)s",
+                name="%(cacheName)s"
+              }[$__rate_interval]
+            )
+          )
+        ||| % config,
+        '{{operation}}'
+      ) +
       $.stack +
-      { yaxes: $.yaxes('ops') },
+      { yaxes: $.yaxes('ops') } +
+      $.panelDescription(
+        'Requests Per Second',
+        |||
+          Requests per second made to 
+          the %(cacheNameReadable)s
+          from the %(component)s, 
+          separated into request type.
+        ||| % config
+      ),
     )
     .addPanel(
       $.panel('Latency (getmulti)') +
-      $.latencyPanel('thanos_memcached_operation_duration_seconds', '{%s,operation="getmulti",component="%s",name="%s"}' % [$.jobMatcher(jobName), component, cacheName])
+      $.latencyPanel(
+        'thanos_memcached_operation_duration_seconds',
+        |||
+          {
+            %(jobMatcher)s,
+            operation="getmulti",
+            component="%(component)s",
+            name="%(cacheName)s"
+          }
+        ||| % config
+      ) +
+      $.panelDescription(
+        'Latency (getmulti)',
+        |||
+          The average, median (50th percentile) and 99th percentile 
+          time to satisfy a “getmulti” request 
+          made by the %(component)s,
+          which retrieves multiple items from the cache.
+        ||| % config
+      )
     )
     .addPanel(
       $.panel('Hit ratio') +
-      $.queryPanel('sum(rate(thanos_cache_memcached_hits_total{%s,component="%s",name="%s"}[$__rate_interval])) / sum(rate(thanos_cache_memcached_requests_total{%s,component="%s",name="%s"}[$__rate_interval]))' %
-                   [
-                     $.jobMatcher(jobName),
-                     component,
-                     cacheName,
-                     $.jobMatcher(jobName),
-                     component,
-                     cacheName,
-                   ], 'items') +
-      { yaxes: $.yaxes('percentunit') },
+      $.queryPanel(
+        |||
+          sum(
+            rate(
+              thanos_cache_memcached_hits_total{
+                %(jobMatcher)s,
+                component="%(component)s",
+                name="%(cacheName)s"
+              }[$__rate_interval]
+            )
+          ) 
+          / 
+          sum(
+            rate(
+              thanos_cache_memcached_requests_total{
+                %(jobMatcher)s,
+                component="%(component)s",
+                name="%(cacheName)s"
+              }[$__rate_interval]
+            )
+          )
+        ||| % config,
+        'items'
+      ) +
+      { yaxes: $.yaxes('percentunit') } +
+      $.panelDescription(
+        'Hit Ratio',
+        |||
+          The fraction of %(component)s requests to the 
+          %(cacheNameReadable)s that successfully return data. 
+          Requests that miss the cache must go to 
+          object storage for the underlying data. 
+        ||| % config
+      ),
     ),
 
   filterNodeDiskContainer(containerName)::
     |||
       ignoring(%s) group_right() (label_replace(count by(%s, %s, device) (container_fs_writes_bytes_total{%s,container="%s",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
     ||| % [$._config.per_instance_label, $._config.per_node_label, $._config.per_instance_label, $.namespaceMatcher(), containerName],
+
+  panelDescription(title, description):: {
+    description: |||
+      ### %s
+      %s
+    ||| % [title, description],
+  },
 }

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -36,13 +36,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           then d.addMultiTemplate('job', 'cortex_build_info', 'job')
           else d
                .addMultiTemplate('cluster', 'cortex_build_info', 'cluster')
-               .addMultiTemplate('namespace', 'cortex_build_info', 'namespace')
+               .addMultiTemplate('namespace', 'cortex_build_info{cluster=~"$cluster"}', 'namespace')
         else
           if $._config.singleBinary
           then d.addTemplate('job', 'cortex_build_info', 'job')
           else d
                .addTemplate('cluster', 'cortex_build_info', 'cluster')
-               .addTemplate('namespace', 'cortex_build_info', 'namespace'),
+               .addTemplate('namespace', 'cortex_build_info{cluster=~"$cluster"}', 'namespace'),
 
     },
 

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -423,7 +423,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           "/dev/(.*)"
         ) * 0
       )
-    ||| % [$._config.per_instance_label, $._config.per_node_label, $._config.per_instance_label, $.namespaceMatcher(), containerName],
+    ||| % [
+      $._config.per_instance_label,
+      $._config.per_node_label,
+      $._config.per_instance_label,
+      $.namespaceMatcher(),
+      containerName,
+    ],
 
   panelDescription(title, description):: {
     description: |||

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -336,11 +336,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
       jobMatcher: $.jobMatcher(jobName),
       component: component,
       cacheName: cacheName,
-      cacheNameReadable: std.strReplace(cacheName, '-', ' '),
     };
     super.row(title)
     .addPanel(
-      $.panel('Requests per second') +
+      $.panel('Requests / sec') +
       $.queryPanel(
         |||
           sum by(operation) (

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -333,14 +333,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
   ],
 
   thanosMemcachedCache(title, jobName, component, cacheName)::
-        local config = {
-          jobMatcher: $.jobMatcher(jobName),
-          component: component,
-          cacheName: cacheName,
-          cacheNameReadable: std.strReplace(cacheName, '-', ' '),
-        };
+    local config = {
+      jobMatcher: $.jobMatcher(jobName),
+      component: component,
+      cacheName: cacheName,
+      cacheNameReadable: std.strReplace(cacheName, '-', ' '),
+    };
     super.row(title)
-     .addPanel(
+    .addPanel(
       $.panel('Requests Per Second') +
       $.queryPanel(
         |||

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -30,7 +30,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         else self,
 
       addRows(rows)::
-        addRowsIf(true, rows),
+        self.addRowsIf(true, rows),
 
       addClusterSelectorTemplates(multi=true)::
         local d = self {
@@ -379,7 +379,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addPanel(
-      $.panel('QPS') +
+      $.panel('Requests Per Second') +
       $.queryPanel(
         |||
           sum by(operation) (

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -340,7 +340,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     };
     super.row(title)
     .addPanel(
-      $.panel('Requests Per Second') +
+      $.panel('Requests per second') +
       $.queryPanel(
         |||
           sum by(operation) (

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -403,7 +403,26 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
   filterNodeDiskContainer(containerName)::
     |||
-      ignoring(%s) group_right() (label_replace(count by(%s, %s, device) (container_fs_writes_bytes_total{%s,container="%s",device!~".*sda.*"}), "device", "$1", "device", "/dev/(.*)") * 0)
+      ignoring(%s) group_right() (
+        label_replace(
+          count by(
+            %s, 
+            %s, 
+            device
+          ) 
+          (
+            container_fs_writes_bytes_total{
+              %s,
+              container="%s",
+              device!~".*sda.*"
+            }
+          ), 
+          "device", 
+          "$1", 
+          "device", 
+          "/dev/(.*)"
+        ) * 0
+      )
     ||| % [$._config.per_instance_label, $._config.per_node_label, $._config.per_instance_label, $.namespaceMatcher(), containerName],
 
   panelDescription(title, description):: {

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -61,7 +61,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
           else d
                .addTemplate('cluster', 'cortex_build_info', 'cluster')
                .addTemplate('namespace', 'cortex_build_info{cluster=~"$cluster"}', 'namespace'),
-      editable: true,
     },
 
   // The mixin allow specialism of the job selector depending on if its a single binary

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -4,7 +4,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   'cortex-reads.json':
     ($.dashboard('Cortex / Reads') + { uid: '8d6ba60eccc4b6eedfa329b24b1bd339' })
     .addClusterSelectorTemplates()
-    .addRow(
+    .addRowIf(
+      $._config.show_dashboard_descriptions.reads,
       ($.row('Reads dashboard description') { height: '175px', showTitle: false })
       .addPanel(
         $.textPanel('', |||
@@ -12,7 +13,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             This dashboard shows health metrics for the Cortex read path.
             It is broken into sections for each service on the read path, and organized by the order in which the read request flows.
             <br/>
-            Incoming queries travel from the gateway → query frontend → query scheduler → querier → ingester and/or store-gateway (depending on the age of the query).
+            Incoming queries travel from the gateway → query frontend → query scheduler → querier → ingester and/or store-gateway (depending on the time range of the query).
             <br/>
             For each service, there are 3 panels showing (1) requests per second to that service, (2) average, median, and p99 latency of requests to that service, and (3) p99 latency of requests to each instance of that service.
           </p> 
@@ -42,14 +43,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
               cortex_request_duration_seconds_count{
                 %(queryFrontend)s,
                 route=~"(prometheus|api_prom)_api_v1_query"
-              }[1h]
+              }[$__rate_interval]
             )
           ) + 
           sum(
             rate(
               cortex_prometheus_rule_evaluations_total{
                 %(ruler)s
-              }[1h]
+              }[$__rate_interval]
             )
           )
         ||| % {
@@ -73,7 +74,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               cortex_request_duration_seconds_count{
                 %(queryFrontend)s,
                 route=~"(prometheus|api_prom)_api_v1_query_range"
-              }[1h]
+              }[$__rate_interval]
             )
           )
         ||| % {
@@ -132,7 +133,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           |||
             <p>
               The query scheduler is an optional service that moves
-              the internal queue from the query frontend into a
+              the internal queue from the query-frontend into a
               separate component.
               If this service is not deployed, 
               these panels will show "No data."
@@ -241,7 +242,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.row('Memcached – blocks storage – block index cache (store-gateway accesses)')  // Resembles thanosMemcachedCache
+      $.row('Memcached – Blocks storage – Block index cache (store-gateway accesses)')  // Resembles thanosMemcachedCache
       .addPanel(
         $.panel('Requests / sec') +
         $.queryPanel(
@@ -314,7 +315,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.thanosMemcachedCache(
-        'Memcached – blocks storage – chunks cache (store-gateway accesses)',
+        'Memcached – Blocks storage – Chunks cache (store-gateway accesses)',
         $._config.job_names.store_gateway,
         'store-gateway',
         'chunks-cache'
@@ -323,7 +324,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.thanosMemcachedCache(
-        'Memcached – blocks storage – metadata cache (store-gateway accesses)',
+        'Memcached – Blocks storage – Metadata cache (store-gateway accesses)',
         $._config.job_names.store_gateway,
         'store-gateway',
         'metadata-cache'
@@ -332,7 +333,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.thanosMemcachedCache(
-        'Memcached – blocks storage – metadata cache (querier accesses)',
+        'Memcached – Blocks storage – Metadata cache (querier accesses)',
         $._config.job_names.querier,
         'querier',
         'metadata-cache'

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -90,7 +90,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway)) +
         $.panelDescriptionRps('gateway')
       )
@@ -111,7 +111,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Query Frontend')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.query_frontend)) +
         $.panelDescriptionRps('query frontend')
       )
@@ -146,7 +146,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       )
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler)) +
         $.panelDescriptionRps('query scheduler')
       )
@@ -161,16 +161,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
       .addPanel(
         $.textPanel('', |||
           <p>
-            The query results is an optional service is one of 4 
-            optional caches that can be deployed as part of a Cortex
-            cluster to improve query performance.
-            It is used by the query-frontend to cache entire results
-            of queries.
+            The query results cache is one of 4 optional caches
+            that can be deployed as part of a GEM cluster to improve query performance. 
+            It is used by the query-frontend to cache entire results of queries.
           </p>
         |||)
       )
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{method=~"frontend.+", %s}' % $.jobMatcher($._config.job_names.query_frontend)) +
         $.panelDescriptionRps('query results')
       )
@@ -183,7 +181,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Querier')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.querier)) +
         $.panelDescriptionRps(
           'querier'
@@ -217,7 +215,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       )
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}' % $.jobMatcher($._config.job_names.ingester)) +
         $.panelDescriptionRps('ingester')
       )
@@ -252,7 +250,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       )
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/gatewaypb.StoreGateway/.*"}' % $.jobMatcher($._config.job_names.store_gateway)) +
         $.panelDescriptionRps('store gateway')
       )
@@ -274,7 +272,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Index')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{%s,method="store.index-cache-read.memcache.fetch"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -286,7 +284,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Chunks')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{%s,method="chunksmemcache.fetch"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -310,7 +308,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       )
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.queryPanel(
           |||
             sum by(operation) (
@@ -430,7 +428,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_cassandra_request_duration_seconds_count{%s, operation="SELECT"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -443,7 +441,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/ReadRows"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -456,7 +454,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_dynamo_request_duration_seconds_count{%s, operation="DynamoDB.QueryPages"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -469,7 +467,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_gcs_request_duration_seconds_count{%s, operation="GET"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -35,7 +35,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
          showTitle: false,
        })
       .addPanel(
-        $.panel('Instant queries per second') +
+        $.panel('Instant queries / sec') +
         $.statPanel(|||
           sum(
             rate(
@@ -66,7 +66,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ),
       )
       .addPanel(
-        $.panel('Range queries per second') +
+        $.panel('Range queries / sec') +
         $.statPanel(|||
           sum(
             rate(
@@ -91,7 +91,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway))
       )
       .addPanel(
@@ -109,7 +109,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Query Frontend')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.query_frontend))
       )
       .addPanel(
@@ -141,7 +141,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       )
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
       )
       .addPanel(
@@ -152,7 +152,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Cache - Query Results')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{method=~"frontend.+", %s}' % $.jobMatcher($._config.job_names.query_frontend))
       )
       .addPanel(
@@ -163,7 +163,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Querier')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -181,7 +181,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Ingester')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -200,7 +200,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/gatewaypb.StoreGateway/.*"}' % $.jobMatcher($._config.job_names.store_gateway))
       )
       .addPanel(
@@ -219,7 +219,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Index')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{%s,method="store.index-cache-read.memcache.fetch"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -231,7 +231,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Chunks')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{%s,method="chunksmemcache.fetch"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -243,7 +243,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'blocks'),
       $.row('Memcached – blocks storage – block index cache (store-gateway accesses)')  // Resembles thanosMemcachedCache
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.queryPanel(
           |||
             sum by(operation) (
@@ -343,7 +343,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_cassandra_request_duration_seconds_count{%s, operation="SELECT"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -356,7 +356,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/ReadRows"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -369,7 +369,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_dynamo_request_duration_seconds_count{%s, operation="DynamoDB.QueryPages"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -382,7 +382,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_gcs_request_duration_seconds_count{%s, operation="GET"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -35,7 +35,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
          showTitle: false,
        })
       .addPanel(
-        $.panel('Instant Queries / s') +
+        $.panel('Instant queries / sec') +
         $.statPanel(|||
           sum(
             rate(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -57,7 +57,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ruler: $.jobMatcher($._config.job_names.ruler),
         }, format='reqps') +
         $.panelDescription(
-          'Instant Queries Per Second',
+          'Instant Queries per second',
           |||
             Rate of instant queries per second being made to the system.
             Includes both queries made to the <tt>/prometheus</tt> API as 

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -35,7 +35,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
          showTitle: false,
        })
       .addPanel(
-        $.panel('Instant queries / sec') +
+        $.panel('Instant queries per second') +
         $.statPanel(|||
           sum(
             rate(
@@ -57,7 +57,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ruler: $.jobMatcher($._config.job_names.ruler),
         }, format='reqps') +
         $.panelDescription(
-          'Instant Queries per second',
+          'Instant queries per second',
           |||
             Rate of instant queries per second being made to the system.
             Includes both queries made to the <tt>/prometheus</tt> API as 
@@ -66,7 +66,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ),
       )
       .addPanel(
-        $.panel('Range queries / s') +
+        $.panel('Range queries per second') +
         $.statPanel(|||
           sum(
             rate(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -5,7 +5,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ($.dashboard('Cortex / Reads') + { uid: '8d6ba60eccc4b6eedfa329b24b1bd339' })
     .addClusterSelectorTemplates()
     .addRow(
-      ($.row('Reads Dashboard Description') { height: '175px', showTitle: false })
+      ($.row('Reads dashboard description') { height: '175px', showTitle: false })
       .addPanel(
         $.textPanel('', |||
           <p>

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -66,7 +66,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ),
       )
       .addPanel(
-        $.panel('Range Queries / s') +
+        $.panel('Range queries / s') +
         $.statPanel(|||
           sum(
             rate(

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -5,116 +5,269 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ($.dashboard('Cortex / Reads') + { uid: '8d6ba60eccc4b6eedfa329b24b1bd339' })
     .addClusterSelectorTemplates()
     .addRow(
+      ($.row('Reads Summary') { height: '175px', showTitle: false })
+      .addPanel(
+        $.textPanel('', |||
+          <p>
+            This dashboard shows various health metrics for the Cortex read path.
+            It is broken into sections for each service on the read path, and organized by the order in which the read request flows.
+            <br/>
+            Incoming queries travel from the gateway → query frontend → query scheduler → querier → ingester and/or store-gateway (depending on the age of the query).
+          </p> 
+          <p>
+            The dashboard shows metrics for the 4 optional caches that can be deployed with Cortex: 
+            the query results cache, the metadata cache, the chunks cache, and the index cache. 
+            <br/>
+            These panels will show “no data” if the caches are not deployed. 
+          </p>
+          <p>
+            Lastly, it also includes metrics for how the ingester and store-gateway interact with object storage. 
+          </p>
+        |||),
+      )
+    )
+    .addRow(
+      ($.row('Headlines') +
+       {
+         height: '100px',
+         showTitle: false,
+       })
+      .addPanel(
+        $.panel('Instant Queries / s') +
+        $.statPanel(|||
+          sum(
+            rate(
+              cortex_request_duration_seconds_count{
+                %(queryFrontend)s,
+                route=~"(prometheus|api_prom)_api_v1_query"
+              }[1h]
+            )
+          ) + 
+          sum(
+            rate(
+              cortex_prometheus_rule_evaluations_total{
+                %(ruler)s
+              }[1h]
+            )
+          )
+        ||| % {
+          queryFrontend: $.jobMatcher($._config.job_names.query_frontend),
+          ruler: $.jobMatcher($._config.job_names.ruler),
+        }, format='reqps') +
+        $.panelDescription(
+          'Instant Queries Per Second',
+          |||
+            Rate of instant queries per second being made to the system.
+            Includes both queries made to the <tt>/prometheus</tt> API as 
+            well as queries from the ruler.
+          |||
+        ),
+      )
+      .addPanel(
+        $.panel('Range Queries / s') +
+        $.statPanel(|||
+          sum(
+            rate(
+              cortex_request_duration_seconds_count{
+                %(queryFrontend)s,
+                route=~"(prometheus|api_prom)_api_v1_query_range"
+              }[1h]
+            )
+          )
+        ||| % {
+          queryFrontend: $.jobMatcher($._config.job_names.query_frontend),
+        }, format='reqps') +
+        $.panelDescription(
+          'Range Queries Per Second',
+          |||
+            Rate of range queries per second being made to 
+            Cortex via the <tt>/prometheus</tt> API. 
+            (The ruler does not issue range queries).
+          |||
+        ),
+      )
+    )
+    .addRow(
       $.row('Gateway')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway)) +
+        $.panelDescriptionRps('gateway')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')]) +
+        $.panelDescriptionLatency('gateway')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"(prometheus|api_prom)_api_v1_.+"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.gateway)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('gateway')
       )
     )
     .addRow(
       $.row('Query Frontend')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.query_frontend))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.query_frontend)) +
+        $.panelDescriptionRps('query frontend')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')]) +
+        $.panelDescriptionLatency('query frontend')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"(prometheus|api_prom)_api_v1_.+"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.query_frontend)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('query frontend')
       )
     )
     .addRow(
       $.row('Query Scheduler')
       .addPanel(
+        $.textPanel(
+          '',
+          |||
+            <p>
+              The query scheduler is an optional service that moves
+              the internal queue from the query frontend into a
+              separate component.
+              If this service is not deployed, 
+              these panels will show "No Data."
+            </p>
+          |||
+        )
+      )
+      .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
+        $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler)) +
+        $.panelDescriptionRps('query scheduler')
       )
       .addPanel(
         $.panel('Latency (Time in Queue)') +
-        $.latencyPanel('cortex_query_scheduler_queue_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
+        $.latencyPanel('cortex_query_scheduler_queue_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.query_scheduler)) +
+        $.panelDescriptionLatency('query scheduler')
       )
     )
     .addRow(
       $.row('Cache - Query Results')
       .addPanel(
+        $.textPanel('', |||
+          <p>
+            The query results is an optional service is one of 4 
+            optional caches that can be deployed as part of a Cortex
+            cluster to improve query performance.
+            It is used by the query-frontend to cache entire results
+            of queries.
+          </p>
+        |||)
+      )
+      .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_cache_request_duration_seconds_count{method=~"frontend.+", %s}' % $.jobMatcher($._config.job_names.query_frontend))
+        $.qpsPanel('cortex_cache_request_duration_seconds_count{method=~"frontend.+", %s}' % $.jobMatcher($._config.job_names.query_frontend)) +
+        $.panelDescriptionRps('query results')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_cache_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('method', 'frontend.+')])
+        utils.latencyRecordingRulePanel('cortex_cache_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('method', 'frontend.+')]) +
+        $.panelDescriptionLatency('query results')
       )
     )
     .addRow(
       $.row('Querier')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.querier))
+        $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.querier)) +
+        $.panelDescriptionRps(
+          'querier'
+        )
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_querier_request_duration_seconds', $.jobSelector($._config.job_names.querier) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')])
+        utils.latencyRecordingRulePanel('cortex_querier_request_duration_seconds', $.jobSelector($._config.job_names.querier) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')]) +
+        $.panelDescriptionLatency('querier')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_querier_request_duration_seconds_bucket{%s, route=~"(prometheus|api_prom)_api_v1_.+"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.querier)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('querier')
       )
     )
     .addRow(
       $.row('Ingester')
       .addPanel(
+        $.textPanel(
+          '',
+          |||
+            <p>
+              For short term queries, queriers go 
+              to the ingester to fetch the data. 
+            </p>
+          |||
+        )
+      )
+      .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}' % $.jobMatcher($._config.job_names.ingester))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}' % $.jobMatcher($._config.job_names.ingester)) +
+        $.panelDescriptionRps('ingester')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.re('route', '/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.re('route', '/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata')]) +
+        $.panelDescriptionLatency('ingester')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('ingester')
       )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway')
       .addPanel(
+        $.textPanel(
+          '',
+          |||
+            <p>
+              For longer term queries, queriers go to the store-gateways to 
+              fetch the data. 
+              Store-gateways are responsible for fetching the data from object 
+              storage. 
+            </p>
+          |||
+        )
+      )
+      .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/gatewaypb.StoreGateway/.*"}' % $.jobMatcher($._config.job_names.store_gateway))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/gatewaypb.StoreGateway/.*"}' % $.jobMatcher($._config.job_names.store_gateway)) +
+        $.panelDescriptionRps('store gateway')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.store_gateway) + [utils.selector.re('route', '/gatewaypb.StoreGateway/.*')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.store_gateway) + [utils.selector.re('route', '/gatewaypb.StoreGateway/.*')]) +
+        $.panelDescriptionLatency('store gateway')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/gatewaypb.StoreGateway/.*"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.store_gateway)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('store gateway')
       )
     )
     .addRowIf(
@@ -143,34 +296,134 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.row('Memcached – Blocks Storage – Block Index (Store-gateway)')
+      $.row('Memcached – Blocks Storage – Block Index (Store-gateway)')  // Resembles thanosMemcachedCache
+      .addPanel(
+        $.textPanel(
+          '',
+          |||
+            <p>
+              The block index cache is an optional component that the 
+              store-gateway will check before going to object storage.
+              This helps reduce calls to the object store.
+            </p>
+          |||
+        )
+      )
       .addPanel(
         $.panel('QPS') +
-        $.queryPanel('sum by(operation) (rate(thanos_memcached_operations_total{component="store-gateway",name="index-cache", %s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.store_gateway), '{{operation}}') +
+        $.queryPanel(
+          |||
+            sum by(operation) (
+              rate(
+                thanos_memcached_operations_total{
+                  component="store-gateway",
+                  name="index-cache",
+                  %s
+                }[$__rate_interval]
+              )
+            )
+          ||| % $.jobMatcher($._config.job_names.store_gateway), '{{operation}}'
+        ) +
         $.stack +
-        { yaxes: $.yaxes('ops') },
+        { yaxes: $.yaxes('ops') } +
+        $.panelDescription(
+          'Requests Per Second',
+          |||
+            Requests per second made to 
+            the block index cache
+            from the store-gateway,
+            separated into request type.
+          |||
+        ),
       )
       .addPanel(
         $.panel('Latency (getmulti)') +
-        $.latencyPanel('thanos_memcached_operation_duration_seconds', '{%s,operation="getmulti",component="store-gateway",name="index-cache"}' % $.jobMatcher($._config.job_names.store_gateway))
+        $.latencyPanel(
+          'thanos_memcached_operation_duration_seconds',
+          |||
+            {
+              %s,
+              operation="getmulti",
+              component="store-gateway",
+              name="index-cache"
+            }
+          ||| % $.jobMatcher($._config.job_names.store_gateway)
+        ) +
+        $.panelDescription(
+          'Latency (getmulti)',
+          |||
+            The average, median (50th percentile) and 99th percentile
+            time to satisfy a “getmulti” request 
+            from the store-gateway, 
+            which retrieves multiple items from the cache. 
+          |||
+        )
       )
       .addPanel(
         $.panel('Hit ratio') +
-        $.queryPanel('sum by(item_type) (rate(thanos_store_index_cache_hits_total{component="store-gateway",%s}[$__rate_interval])) / sum by(item_type) (rate(thanos_store_index_cache_requests_total{component="store-gateway",%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.store_gateway), $.jobMatcher($._config.job_names.store_gateway)], '{{item_type}}') +
-        { yaxes: $.yaxes('percentunit') },
+        $.queryPanel(
+          |||
+            sum by(item_type) (
+              rate(
+                thanos_store_index_cache_hits_total{
+                  component="store-gateway",
+                  %s
+                }[$__rate_interval]
+              )
+            ) 
+            / 
+            sum by(item_type) (
+              rate(
+                thanos_store_index_cache_requests_total{
+                  component="store-gateway",
+                  %s
+                }[$__rate_interval]
+              )
+            )
+          ||| % [
+            $.jobMatcher($._config.job_names.store_gateway),
+            $.jobMatcher($._config.job_names.store_gateway),
+          ],
+          '{{item_type}}'
+        ) +
+        { yaxes: $.yaxes('percentunit') } +
+        $.panelDescription(
+          'Hit Ratio',
+          |||
+            The fraction of requests to the 
+            block index cache that successfully return data. 
+            Requests that miss the cache must go to 
+            object storage for the underlying data. 
+          |||
+        ),
       )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.thanosMemcachedCache('Memcached – Blocks Storage – Chunks (Store-gateway)', $._config.job_names.store_gateway, 'store-gateway', 'chunks-cache')
+      $.thanosMemcachedCache(
+        'Memcached – Blocks Storage – Chunks (Store-gateway)',
+        $._config.job_names.store_gateway,
+        'store-gateway',
+        'chunks-cache'
+      )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.thanosMemcachedCache('Memcached – Blocks Storage – Metadata (Store-gateway)', $._config.job_names.store_gateway, 'store-gateway', 'metadata-cache')
+      $.thanosMemcachedCache(
+        'Memcached – Blocks Storage – Metadata (Store-gateway)',
+        $._config.job_names.store_gateway,
+        'store-gateway',
+        'metadata-cache'
+      )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.thanosMemcachedCache('Memcached – Blocks Storage – Metadata (Querier)', $._config.job_names.querier, 'querier', 'metadata-cache')
+      $.thanosMemcachedCache(
+        'Memcached – Blocks Storage – Metadata (Querier)',
+        $._config.job_names.querier,
+        'querier',
+        'metadata-cache'
+      )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'chunks') &&
@@ -225,21 +478,43 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     // Object store metrics for the store-gateway.
-    .addRowIf(
+    .addRowsIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.objectStorePanels1('Store-gateway - Blocks Object Store', 'store-gateway'),
-    )
-    .addRowIf(
-      std.member($._config.storage_engine, 'blocks'),
-      $.objectStorePanels2('', 'store-gateway'),
+      $.getObjectStoreRows('Store-gateway - Blocks Object Store', 'store-gateway')
     )
     // Object store metrics for the querier.
-    .addRowIf(
+    .addRowsIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.objectStorePanels1('Querier - Blocks Object Store', 'querier'),
-    )
-    .addRowIf(
-      std.member($._config.storage_engine, 'blocks'),
-      $.objectStorePanels2('', 'querier'),
+      $.getObjectStoreRows('Querier - Blocks Object Store', 'querier')
     ),
-}
+} +
+(
+  {
+    panelDescriptionRps(service)::
+      $.panelDescription(
+        'Requests Per Second',
+        |||
+          Read requests per second made to the %s(s).
+        ||| % service
+      ),
+
+    panelDescriptionLatency(service)::
+      $.panelDescription(
+        'Latency',
+        |||
+          Across all %s instances, the average, median 
+          (50th percentile), and 99th percentile time to respond 
+          to a request.  
+        ||| % service
+      ),
+
+    panelDescriptionP99Latency(service)::
+      $.panelDescription(
+        'Per Instance P99 Latency',
+        |||
+          The 99th percentile latency for each individual 
+          instance of the %s service.
+        ||| % service
+      ),
+  }
+)

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -92,7 +92,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Gateway')
       .addPanel(
         $.panel('Requests Per Second') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway)) 
+        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway))
       )
       .addPanel(
         $.panel('Latency') +
@@ -114,7 +114,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')]) 
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.query_frontend) + [utils.selector.re('route', '(prometheus|api_prom)_api_v1_.+')])
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
@@ -142,7 +142,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
       .addPanel(
         $.panel('Requests Per Second') +
-        $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler)) 
+        $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
       )
       .addPanel(
         $.panel('Latency (Time in Queue)') +
@@ -301,7 +301,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ],
           '{{item_type}}'
         ) +
-        { yaxes: $.yaxes('percentunit') }  +
+        { yaxes: $.yaxes('percentunit') } +
         $.panelDescription(
           'Hit Ratio',
           |||

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -91,7 +91,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.gateway))
       )
       .addPanel(
@@ -109,7 +109,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Query Frontend')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.query_frontend))
       )
       .addPanel(
@@ -141,7 +141,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       )
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_query_scheduler_queue_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.query_scheduler))
       )
       .addPanel(
@@ -152,7 +152,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Cache - Query Results')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{method=~"frontend.+", %s}' % $.jobMatcher($._config.job_names.query_frontend))
       )
       .addPanel(
@@ -163,7 +163,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Querier')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"(prometheus|api_prom)_api_v1_.+"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -181,7 +181,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Ingester')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -200,7 +200,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'blocks'),
       $.row('Store-gateway')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route=~"/gatewaypb.StoreGateway/.*"}' % $.jobMatcher($._config.job_names.store_gateway))
       )
       .addPanel(
@@ -219,7 +219,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Index')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{%s,method="store.index-cache-read.memcache.fetch"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -231,7 +231,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached - Chunks storage - Chunks')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_cache_request_duration_seconds_count{%s,method="chunksmemcache.fetch"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -243,7 +243,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'blocks'),
       $.row('Memcached – Blocks Storage – Block Index Cache (Store-gateway accesses)')  // Resembles thanosMemcachedCache
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.queryPanel(
           |||
             sum by(operation) (
@@ -343,7 +343,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_cassandra_request_duration_seconds_count{%s, operation="SELECT"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -356,7 +356,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/ReadRows"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -369,7 +369,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_dynamo_request_duration_seconds_count{%s, operation="DynamoDB.QueryPages"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(
@@ -382,7 +382,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_gcs_request_duration_seconds_count{%s, operation="GET"}' % $.jobMatcher($._config.job_names.querier))
       )
       .addPanel(

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -4,7 +4,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   'cortex-writes.json':
     ($.dashboard('Cortex / Writes') + { uid: '0156f6d15aa234d452a33a4f13c838e3' })
     .addClusterSelectorTemplates()
-    .addRow(
+    .addRowIf(
+      $._config.show_dashboard_descriptions.writes,
       ($.row('Writes dashboard description') { height: '125px', showTitle: false })
       .addPanel(
         $.textPanel('', |||
@@ -129,7 +130,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
     )
     .addRow(
-      $.row('Key-value store for the ingester ring')
+      $.row('Key-value store for the ingesters ring')
       .addPanel(
         $.panel('Requests / sec') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester))
@@ -227,7 +228,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'Upload latency',
           |||
             The average, median (50th percentile), and 99th percentile time 
-            the ingester takes to upload blocks to object storage.
+            the ingesters take to upload blocks to object storage.
           |||
         ),
       )
@@ -256,7 +257,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panelDescription(
           'Compaction latency',
           |||
-            The average, median (50th percentile), and 99th percentile time ingesters take to compact head blocks
+            The average, median (50th percentile), and 99th percentile time ingesters take to compact TSDB head blocks
             on the local filesystem.
           |||
         ),
@@ -264,7 +265,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.row('Ingester - blocks storage - TSDB write ahead log (WAL)')
+      $.row('Ingester - Blocks storage - TSDB write ahead log (WAL)')
       .addPanel(
         $.successFailurePanel(
           'WAL truncations / sec',

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -195,7 +195,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_gcs_request_duration_seconds_count{%s, operation="POST"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -282,7 +282,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.row('Ingester - Blocks storage - TSDB WAL')
+      ($.row('Ingester - Blocks storage - TSDB WAL') {height: "32px"})
       .addPanel(
         $.textPanel('', |||
           <p>
@@ -291,6 +291,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
           </p> 
         |||),
       )
+    )
+    .addRowIf(
+      std.member($._config.storage_engine, 'blocks'),
+      ($.row('') {showTitle: false})
       .addPanel(
         $.successFailurePanel(
           'WAL truncations / sec',

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -33,7 +33,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
          showTitle: false,
        })
       .addPanel(
-        $.panel('Samples / s') +
+        $.panel('Samples per second') +
         $.statPanel(
           'sum(%(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m{%(job)s})' % (
             $._config {
@@ -208,12 +208,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Ingester - Blocks storage - Shipper')
       .addPanel(
         $.successFailurePanel(
-          'Uploaded blocks / sec',
+          'Uploaded blocks per second',
           'sum(rate(cortex_ingester_shipper_uploads_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
         $.panelDescription(
-          'Uploaded blocks / sec',
+          'Uploaded blocks per second',
           |||
             The rate of blocks being uploaded from the ingesters 
             to object storage.
@@ -237,12 +237,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Ingester - Blocks storage - TSDB Head')
       .addPanel(
         $.successFailurePanel(
-          'Compactions / sec',
+          'Compactions per second',
           'sum(rate(cortex_ingester_tsdb_compactions_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_compactions_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
         $.panelDescription(
-          'Compactions / sec',
+          'Compactions per second',
           |||
             Ingesters maintain a local TSDB per-tenant on disk. Each TSDB maintains a head block for each
             active time series; these blocks get periodically compacted (by default, every 2h).
@@ -267,12 +267,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Ingester - blocks storage - TSDB write ahead log (WAL)')
       .addPanel(
         $.successFailurePanel(
-          'WAL truncations / sec',
+          'WAL truncations per second',
           'sum(rate(cortex_ingester_tsdb_wal_truncations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
         $.panelDescription(
-          'WAL truncations / sec',
+          'WAL truncations per second',
           |||
             The WAL is truncated each time a new TSDB block is written. This panel measures the rate of 
             truncations.
@@ -281,12 +281,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
       .addPanel(
         $.successFailurePanel(
-          'Checkpoints created / sec',
+          'Checkpoints created per second',
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
         $.panelDescription(
-          'Checkpoints created / sec',
+          'Checkpoints created per second',
           |||
             Checkpoints are created as part of the WAL truncation process. 
             This metric measures the rate of checkpoint creation.
@@ -306,7 +306,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ),
       )
       .addPanel(
-        $.panel('Corruptions / sec') +
+        $.panel('Corruptions per second') +
         $.queryPanel([
           'sum(rate(cortex_ingester_wal_corruptions_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
           'sum(rate(cortex_ingester_tsdb_mmap_chunk_corruptions_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -61,7 +61,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.gateway)) +
         $.panelDescriptionRps('gateway')
       )
@@ -82,7 +82,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Distributor')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.distributor)) +
         $.panelDescriptionRps('distributor')
       )
@@ -103,7 +103,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('KV Store (HA Dedupe)')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.distributor)) +
         $.panelDescriptionRpsKvStoreDedupe()
       )
@@ -116,7 +116,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Ingester')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester)) +
         $.panelDescriptionRps('ingester')
       )
@@ -137,7 +137,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('KV Store (Ring)')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester)) +
         $.panelDescriptionRpsKvStoreRing()
       )
@@ -151,7 +151,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_memcache_request_duration_seconds_count{%s,method="Memcache.Put"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -164,7 +164,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_cassandra_request_duration_seconds_count{%s, operation="INSERT"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -177,7 +177,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/MutateRows"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -190,7 +190,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_dynamo_request_duration_seconds_count{%s, operation="DynamoDB.BatchWriteItem"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -203,7 +203,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.qpsPanel('cortex_gcs_request_duration_seconds_count{%s, operation="POST"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -254,7 +254,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Compactions latency') +
         $.latencyPanel('cortex_ingester_tsdb_compaction_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.ingester)) +
         $.panelDescription(
-          'Compaction Latency',
+          'Compaction latency',
           |||
             The average, median (50th percentile), and 99th percentile time ingesters take to compact head blocks
             on the local filesystem.

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -298,7 +298,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.queryPanel('sum(rate(cortex_ingester_tsdb_wal_truncate_duration_seconds_sum{%s}[$__rate_interval])) / sum(rate(cortex_ingester_tsdb_wal_truncate_duration_seconds_count{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)], 'avg') +
         { yaxes: $.yaxes('s') } +
         $.panelDescription(
-          'WAL Truncations Latency (including checkpointing)',
+          'WAL truncations latency (including checkpointing)',
           |||
             Average time taken to perform a full WAL truncation, 
             including the time taken for the checkpointing to complete.

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -5,6 +5,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ($.dashboard('Cortex / Writes') + { uid: '0156f6d15aa234d452a33a4f13c838e3' })
     .addClusterSelectorTemplates()
     .addRow(
+      ($.row('Writes Summary') { height: '125px', showTitle: false })
+      .addPanel(
+        $.textPanel('', |||
+          <p>
+            This dashboard shows various health metrics for the Cortex write path.
+            It is broken into sections for each service on the write path, 
+            and organized by the order in which the write request flows.
+            <br/>
+            Incoming metrics data travels from the gateway → distributor → ingester.
+          </p> 
+          <p>
+            It also includes metrics for the key-value (KV) stores used to manage
+            the High Availability Tracker and the Ingesters.
+          </p>
+        |||),
+      )
+    ).addRow(
       ($.row('Headlines') +
        {
          height: '100px',
@@ -18,7 +35,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               job: $.jobMatcher($._config.job_names.distributor),
             }
           ),
-          format='reqps'
+          format='short'
         )
       )
       .addPanel(
@@ -37,7 +54,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.statPanel('count(count by(user) (cortex_ingester_active_series{%s}))' % $.jobMatcher($._config.job_names.ingester), format='short')
       )
       .addPanel(
-        $.panel('QPS') +
+        $.panel('Requests Per Second') +
         $.statPanel('sum(rate(cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}[5m]))' % $.jobMatcher($._config.job_names.gateway), format='reqps')
       )
     )
@@ -45,76 +62,89 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Gateway')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.gateway))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.gateway)) +
+        $.panelDescriptionRps('gateway')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', 'api_(v1|prom)_push')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', 'api_(v1|prom)_push')]) +
+        $.panelDescriptionLatency('gateway')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"api_(v1|prom)_push"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.gateway)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('gateway')
       )
     )
     .addRow(
       $.row('Distributor')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.distributor))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.distributor)) +
+        $.panelDescriptionRps('distributor')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.distributor) + [utils.selector.re('route', '/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.distributor) + [utils.selector.re('route', '/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push')]) +
+        $.panelDescriptionLatency('distributor')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.distributor)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('distributor')
       )
     )
     .addRow(
       $.row('KV Store (HA Dedupe)')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.distributor))
+        $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.distributor)) +
+        $.panelDescriptionRpsKvStoreDedupe()
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_kv_request_duration_seconds', $.jobSelector($._config.job_names.distributor))
+        utils.latencyRecordingRulePanel('cortex_kv_request_duration_seconds', $.jobSelector($._config.job_names.distributor)) +
+        $.panelDescriptionLatencyKvStore()
       )
     )
     .addRow(
       $.row('Ingester')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester)) +
+        $.panelDescriptionRps('ingester')
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.eq('route', '/cortex.Ingester/Push')])
+        utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.ingester) + [utils.selector.eq('route', '/cortex.Ingester/Push')]) +
+        $.panelDescriptionLatency('ingester')
       )
       .addPanel(
         $.panel('Per %s p99 Latency' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="/cortex.Ingester/Push"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], ''
         ) +
-        { yaxes: $.yaxes('s') }
+        { yaxes: $.yaxes('s') } +
+        $.panelDescriptionP99Latency('ingester')
       )
     )
     .addRow(
       $.row('KV Store (Ring)')
       .addPanel(
         $.panel('QPS') +
-        $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester))
+        $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester)) +
+        $.panelDescriptionRpsKvStoreRing()
       )
       .addPanel(
         $.panel('Latency') +
-        utils.latencyRecordingRulePanel('cortex_kv_request_duration_seconds', $.jobSelector($._config.job_names.ingester))
+        utils.latencyRecordingRulePanel('cortex_kv_request_duration_seconds', $.jobSelector($._config.job_names.ingester)) +
+        $.panelDescriptionLatencyKvStore()
       )
     )
     .addRowIf(
@@ -189,36 +219,91 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'Uploaded blocks / sec',
           'sum(rate(cortex_ingester_shipper_uploads_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
+        ) +
+        $.panelDescription(
+          'Uploaded blocks / sec',
+          |||
+            The rate of blocks being uploaded from the ingesters 
+            to the long term storage/object store.
+          |||
         ),
       )
       .addPanel(
         $.panel('Upload latency') +
-        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="ingester",operation="upload"}' % $.jobMatcher($._config.job_names.ingester)),
+        $.latencyPanel('thanos_objstore_bucket_operation_duration_seconds', '{%s,component="ingester",operation="upload"}' % $.jobMatcher($._config.job_names.ingester)) +
+        $.panelDescription(
+          'Upload latency',
+          |||
+            The average, median (50th percentile), and 99th percentile time 
+            the ingester takes to upload blocks to the long term storage/object store.
+          |||
+        ),
       )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.row('Ingester - Blocks storage - TSDB Head')
       .addPanel(
+        $.textPanel('', |||
+          <p>
+            The ingester(s) maintain a local TSDB per-tenant on disk. 
+            These panels contain metrics specific to the rate of 
+            compaction of data on the ingesters’ local TSDBs.
+          </p> 
+        |||),
+      )
+      .addPanel(
         $.successFailurePanel(
           'Compactions / sec',
           'sum(rate(cortex_ingester_tsdb_compactions_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_compactions_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
+        ) +
+        $.panelDescription(
+          'Compactions / sec',
+          |||
+            This is the rate of compaction operations local to the ingesters, 
+            where every 2 hours by default, a new TSDB block is created 
+            by compacting the head block.
+          |||
         ),
       )
       .addPanel(
         $.panel('Compactions latency') +
-        $.latencyPanel('cortex_ingester_tsdb_compaction_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.ingester)),
+        $.latencyPanel('cortex_ingester_tsdb_compaction_duration_seconds', '{%s}' % $.jobMatcher($._config.job_names.ingester)) +
+        $.panelDescription(
+          'Compaction Latency',
+          |||
+            The average, median (50th percentile), and 99th percentile time 
+            the ingester takes to compact the head block into a new TSDB block 
+            on its local filesystem.
+          |||
+        ),
       )
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
       $.row('Ingester - Blocks storage - TSDB WAL')
       .addPanel(
+        $.textPanel('', |||
+          <p>
+            These panels contain metrics for the optional write-ahead-log (WAL) 
+            that can be enabled for the local TSDBs on the ingesters. 
+          </p> 
+        |||),
+      )
+      .addPanel(
         $.successFailurePanel(
           'WAL truncations / sec',
           'sum(rate(cortex_ingester_tsdb_wal_truncations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
+        ) +
+        $.panelDescription(
+          'WAL Truncations / sec',
+          |||
+            The WAL is truncated each time a new TSDB block is written 
+            (by default this is every 2h). This panel measures the rate of 
+            truncations.
+          |||
         ),
       )
       .addPanel(
@@ -226,12 +311,26 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'Checkpoints created / sec',
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
+        ) +
+        $.panelDescription(
+          'Checkpoints created / sec',
+          |||
+            Checkpoints are created as part of the WAL truncation process. 
+            This metric measures the rate of checkpoint creation.
+          |||
         ),
       )
       .addPanel(
         $.panel('WAL truncations latency (includes checkpointing)') +
         $.queryPanel('sum(rate(cortex_ingester_tsdb_wal_truncate_duration_seconds_sum{%s}[$__rate_interval])) / sum(rate(cortex_ingester_tsdb_wal_truncate_duration_seconds_count{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)], 'avg') +
-        { yaxes: $.yaxes('s') },
+        { yaxes: $.yaxes('s') } +
+        $.panelDescription(
+          'WAL Truncations Latency (including checkpointing)',
+          |||
+            Average time taken to perform a full WAL truncation, 
+            including the time taken for the checkpointing to complete.
+          |||
+        ),
       )
       .addPanel(
         $.panel('Corruptions / sec') +
@@ -248,7 +347,71 @@ local utils = import 'mixin-utils/utils.libsonnet';
             WAL: '#E24D42',
             'mmap-ed chunks': '#E28A42',
           },
-        },
+        } +
+        $.panelDescription(
+          'Corruptions / sec',
+          |||
+            Rate of corrupted WAL and mmap-ed chunks.
+          |||
+        ),
       )
     ),
-}
+} +
+(
+  {
+    panelDescriptionRps(service)::
+      $.panelDescription(
+        'Requests Per Second',
+        |||
+          Write requests per second made to the %s(s).
+        ||| % service
+      ),
+
+    panelDescriptionRpsKvStoreDedupe()::
+      $.panelDescription(
+        'Requests Per Second',
+        |||
+          Requests per second made to the key-value store 
+          that manages high-availability deduplication. 
+        |||
+      ),
+
+    panelDescriptionRpsKvStoreRing()::
+      $.panelDescription(
+        'Requests Per Second',
+        |||
+          Requests per second made to the key-value store 
+          used to manage which ingesters own which metrics series.
+        |||
+      ),
+
+
+    panelDescriptionLatency(service)::
+      $.panelDescription(
+        'Latency',
+        |||
+          Across all %s instances, the average, median 
+          (50th percentile), and 99th percentile time to respond 
+          to a request.  
+        ||| % service
+      ),
+
+    panelDescriptionLatencyKvStore()::
+      $.panelDescription(
+        'Latency',
+        |||
+          The average, median (50th percentile), and 99th percentile time 
+          the KV store takes to respond to a request.  
+        |||
+      ),
+
+    panelDescriptionP99Latency(service)::
+      $.panelDescription(
+        'Per Instance P99 Latency',
+        |||
+          The 99th percentile latency for each individual 
+          instance of the %s service.
+        ||| % service
+      ),
+  }
+)

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -59,14 +59,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.statPanel('count(count by(user) (cortex_ingester_active_series{%s}))' % $.jobMatcher($._config.job_names.ingester), format='short')
       )
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.statPanel('sum(rate(cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}[5m]))' % $.jobMatcher($._config.job_names.gateway), format='reqps')
       )
     )
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.gateway))
       )
       .addPanel(
@@ -84,7 +84,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Distributor')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.distributor))
       )
       .addPanel(
@@ -102,7 +102,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Key-Value store for high-availability (HA) deduplication')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.distributor))
       )
       .addPanel(
@@ -113,7 +113,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Ingester')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -131,7 +131,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Key-Value store for the ingester ring')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -143,7 +143,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_memcache_request_duration_seconds_count{%s,method="Memcache.Put"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -156,7 +156,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_cassandra_request_duration_seconds_count{%s, operation="INSERT"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -169,7 +169,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/MutateRows"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -182,7 +182,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
-        $.panel('Requests Per Second') +
+        $.panel('Requests per second') +
         $.qpsPanel('cortex_dynamo_request_duration_seconds_count{%s, operation="DynamoDB.BatchWriteItem"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -272,7 +272,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
         $.panelDescription(
-          'WAL Truncations / sec',
+          'WAL truncations / sec',
           |||
             The WAL is truncated each time a new TSDB block is written. This panel measures the rate of 
             truncations.

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -33,7 +33,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
          showTitle: false,
        })
       .addPanel(
-        $.panel('Samples per second') +
+        $.panel('Samples / sec') +
         $.statPanel(
           'sum(%(group_prefix_jobs)s:cortex_distributor_received_samples:rate5m{%(job)s})' % (
             $._config {
@@ -59,14 +59,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.statPanel('count(count by(user) (cortex_ingester_active_series{%s}))' % $.jobMatcher($._config.job_names.ingester), format='short')
       )
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.statPanel('sum(rate(cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}[5m]))' % $.jobMatcher($._config.job_names.gateway), format='reqps')
       )
     )
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.gateway))
       )
       .addPanel(
@@ -84,7 +84,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Distributor')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push"}' % $.jobMatcher($._config.job_names.distributor))
       )
       .addPanel(
@@ -102,7 +102,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Key-value store for high-availability (HA) deduplication')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.distributor))
       )
       .addPanel(
@@ -113,7 +113,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Ingester')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -131,7 +131,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Key-value store for the ingester ring')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_kv_request_duration_seconds_count{%s}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -143,7 +143,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.storage_engine, 'chunks'),
       $.row('Memcached')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_memcache_request_duration_seconds_count{%s,method="Memcache.Put"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -156,7 +156,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'cassandra'),
       $.row('Cassandra')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_cassandra_request_duration_seconds_count{%s, operation="INSERT"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -169,7 +169,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'bigtable'),
       $.row('BigTable')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_bigtable_request_duration_seconds_count{%s, operation="/google.bigtable.v2.Bigtable/MutateRows"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -182,7 +182,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_index_backend + $._config.chunk_store_backend, 'dynamodb'),
       $.row('DynamoDB')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_dynamo_request_duration_seconds_count{%s, operation="DynamoDB.BatchWriteItem"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -195,7 +195,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       std.member($._config.chunk_store_backend, 'gcs'),
       $.row('GCS')
       .addPanel(
-        $.panel('Requests per second') +
+        $.panel('Requests / sec') +
         $.qpsPanel('cortex_gcs_request_duration_seconds_count{%s, operation="POST"}' % $.jobMatcher($._config.job_names.ingester))
       )
       .addPanel(
@@ -208,12 +208,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Ingester - Blocks storage - Shipper')
       .addPanel(
         $.successFailurePanel(
-          'Uploaded blocks per second',
+          'Uploaded blocks / sec',
           'sum(rate(cortex_ingester_shipper_uploads_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_shipper_upload_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
         $.panelDescription(
-          'Uploaded blocks per second',
+          'Uploaded blocks / sec',
           |||
             The rate of blocks being uploaded from the ingesters 
             to object storage.
@@ -237,7 +237,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Ingester - Blocks storage - TSDB Head')
       .addPanel(
         $.successFailurePanel(
-          'Compactions per second',
+          'Compactions / sec',
           'sum(rate(cortex_ingester_tsdb_compactions_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_compactions_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -267,7 +267,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       $.row('Ingester - blocks storage - TSDB write ahead log (WAL)')
       .addPanel(
         $.successFailurePanel(
-          'WAL truncations per second',
+          'WAL truncations / sec',
           'sum(rate(cortex_ingester_tsdb_wal_truncations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_wal_truncations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -281,7 +281,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
       .addPanel(
         $.successFailurePanel(
-          'Checkpoints created per second',
+          'Checkpoints created / sec',
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_total{%s}[$__rate_interval])) - sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester), $.jobMatcher($._config.job_names.ingester)],
           'sum(rate(cortex_ingester_tsdb_checkpoint_creations_failed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
         ) +
@@ -306,7 +306,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         ),
       )
       .addPanel(
-        $.panel('Corruptions per second') +
+        $.panel('Corruptions / sec') +
         $.queryPanel([
           'sum(rate(cortex_ingester_wal_corruptions_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),
           'sum(rate(cortex_ingester_tsdb_mmap_chunk_corruptions_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.ingester),

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -264,7 +264,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addRowIf(
       std.member($._config.storage_engine, 'blocks'),
-      $.row('Ingester - Blocks storage - TSDB Write Ahead Log (WAL)')
+      $.row('Ingester - blocks storage - TSDB write ahead log (WAL)')
       .addPanel(
         $.successFailurePanel(
           'WAL truncations / sec',


### PR DESCRIPTION
**What this PR does**:

Focussing on the reads and writes dashboards,
added some info panels and hover-over descriptions
for some of the panels.
Some common code used by the compactor also
received additional text content.

New functions:
- addRows
- addRowsIf
...to add a list of rows to a dashboard.

The `thanosMemcachedCache` function has had some of its query text
sprawled out for easier reading and comparison with similar dashboard
queries.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
