### PR TITLE
Set -server.grpc-max-*-msg-size-bytes for ruler and ingester.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [CHANGE] Dashboards: added overridable `job_labels` and `cluster_labels` to the configuration object as label lists to uniquely identify jobs and clusters in the metric names and group-by lists in dashboards. #319
 * [CHANGE] Dashboards: `alert_aggregation_labels` has been removed from the configuration and overriding this value has been deprecated. Instead the labels are now defined by the `cluster_labels` list, and should be overridden accordingly through that list. #319
+* [CHANGE] Ingester/Ruler: set `-server.grpc-max-send-msg-size-bytes` and `-server.grpc-max-send-msg-size-bytes` to sensible default values (10MB). #326
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -32,6 +32,8 @@
       'ingester.max-samples-per-query': $._config.limits.max_samples_per_query,
       'runtime-config.file': '/etc/cortex/overrides.yaml',
       'server.grpc-max-concurrent-streams': 100000,
+      'server.grpc-max-send-msg-size-bytes': 10 * 1024 * 1024,
+      'server.grpc-max-recv-msg-size-bytes': 10 * 1024 * 1024,
     } + (
       if $._config.memcached_index_writes_enabled then
         {

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -24,6 +24,8 @@
       // Limits
       'ruler.max-rules-per-rule-group': $._config.limits.ruler_max_rules_per_rule_group,
       'ruler.max-rule-groups-per-tenant': $._config.limits.ruler_max_rule_groups_per_tenant,
+      'server.grpc-max-send-msg-size-bytes': 10 * 1024 * 1024,
+      'server.grpc-max-recv-msg-size-bytes': 10 * 1024 * 1024,
 
       // Storage
       'querier.second-store-engine': $._config.querier_second_storage_engine,


### PR DESCRIPTION
**What this PR does**:
Set `-server.grpc-max-send-msg-size-bytes` and `-server.grpc-max-send-msg-size-bytes` to sensible default values (10MB).

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
