### PR TITLE
Mark CortexTableSyncFailure and CortexOldChunkInMemory alerts as chunks storage only

### DIFF
--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -361,7 +361,7 @@ _TODO: this playbook has not been written yet._
 
 ### CortexTableSyncFailure
 
-_TODO: this playbook has not been written yet._
+_This alert applies to Cortex chunks storage only._
 
 ### CortexQueriesIncorrect
 
@@ -413,7 +413,7 @@ _TODO: this playbook has not been written yet._
 
 ### CortexOldChunkInMemory
 
-_TODO: this playbook has not been written yet._
+_This alert applies to Cortex chunks storage only._
 
 ### CortexCheckpointCreationFailed
 


### PR DESCRIPTION
**What this PR does**:
Following up https://github.com/grafana/cortex-jsonnet/pull/333, in this PR I'm also marking `CortexTableSyncFailure` and `CortexOldChunkInMemory` as chunks storage only. We're not going to write playbooks for them.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
