### PR TITLE
Change min-step to 15s to show better detail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHANGE] Renamed `CortexCompactorRunFailed` to `CortexCompactorHasNotSuccessfullyRunCompaction`. #334
 * [CHANGE] Renamed `CortexInconsistentConfig` alert to `CortexInconsistentRuntimeConfig` and increased severity to `critical`. #335
 * [CHANGE] Increased `CortexBadRuntimeConfig` alert severity to `critical` and removed support for `cortex_overrides_last_reload_successful` metric (was removed in Cortex 1.3.0). #335
+* [CHANGE] Grafana 'min step' changed to 15s so dashboard show better detail. #340
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. #317
 * [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. #324
 * [ENHANCEMENT] Dashboards: defined container functions for common resources panels: containerDiskWritesPanel, containerDiskReadsPanel, containerDiskSpaceUtilization. #331

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -84,7 +84,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     super.queryPanel(queries, legends, legendLink) + {
       targets: [
         target {
-          interval: '1m',
+          interval: '15s',
         }
         for target in super.targets
       ],
@@ -104,7 +104,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     super.qpsPanel(selector) + {
       targets: [
         target {
-          interval: '1m',
+          interval: '15s',
         }
         for target in super.targets
       ],
@@ -114,7 +114,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     super.latencyPanel(metricName, selector, multiplier) + {
       targets: [
         target {
-          interval: '1m',
+          interval: '15s',
         }
         for target in super.targets
       ],


### PR DESCRIPTION
**What this PR does**:
`$__rate_interval` will be floored at 4x this quantity, so 15s lets us see faster transients than the previous value of 1m.

**Which issue(s) this PR fixes**:
Fixes #339 

**Checklist**
- [x] `CHANGELOG.md` updated
