### PR TITLE
Remove CortexQuerierCapacityFull alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Renamed `CortexInconsistentConfig` alert to `CortexInconsistentRuntimeConfig` and increased severity to `critical`. #335
 * [CHANGE] Increased `CortexBadRuntimeConfig` alert severity to `critical` and removed support for `cortex_overrides_last_reload_successful` metric (was removed in Cortex 1.3.0). #335
 * [CHANGE] Grafana 'min step' changed to 15s so dashboard show better detail. #340
+* [CHANGE] Removed `CortexQuerierCapacityFull` alert. #342
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. #317
 * [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. #324
 * [ENHANCEMENT] Dashboards: defined container functions for common resources panels: containerDiskWritesPanel, containerDiskReadsPanel, containerDiskSpaceUtilization. #331

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -135,21 +135,6 @@
           },
         },
         {
-          alert: 'CortexQuerierCapacityFull',
-          expr: |||
-            prometheus_engine_queries_concurrent_max{job=~".+/(cortex|ruler|querier)"} - prometheus_engine_queries{job=~".+/(cortex|ruler|querier)"} == 0
-          |||,
-          'for': '5m',  // We don't want to block for longer.
-          labels: {
-            severity: 'critical',
-          },
-          annotations: {
-            message: |||
-              {{ $labels.job }} is at capacity processing queries.
-            |||,
-          },
-        },
-        {
           alert: 'CortexFrontendQueriesStuck',
           expr: |||
             sum by (%s) (cortex_query_frontend_queue_length) > 1

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -402,10 +402,6 @@ How to **investigate**:
 - Check the latest runtime config update (it's likely to be broken)
 - Check Cortex logs to get more details about what's wrong with the config
 
-### CortexQuerierCapacityFull
-
-_TODO: this playbook has not been written yet._
-
 ### CortexFrontendQueriesStuck
 
 _TODO: this playbook has not been written yet._


### PR DESCRIPTION
**What this PR does**:
I propose to remove `CortexQuerierCapacityFull` alert. It was added as part of the [initial commit](https://github.com/grafana/cortex-jsonnet/commit/3ff1d4cfcbfa28de1b83c33d42d74749e4c9c97b).

Why removing it? My thoughts:
- The alert fires when a single querier is running queries at full capacity (eg. if configured with 4 workers, all workers run queries for 5 consecutive minutes)
- Having a querier running a full capacity is not an issue per se (if we give a querier 4 workers it means we're willing to use all 4 of them if required) and this looks more alerting on cause then symptom
- We already have alerts on queries stuck in query-frontend/scheduler and we have SLO-based alerts, so I'm not really sure this alert is giving us a real value

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
