### PR TITLE
Replace ruler alerts, and add playbooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Renamed `CortexInconsistentConfig` alert to `CortexInconsistentRuntimeConfig` and increased severity to `critical`. #335
 * [CHANGE] Increased `CortexBadRuntimeConfig` alert severity to `critical` and removed support for `cortex_overrides_last_reload_successful` metric (was removed in Cortex 1.3.0). #335
 * [CHANGE] Grafana 'min step' changed to 15s so dashboard show better detail. #340
+* [CHANGE] Replace `CortexRulerFailedEvaluations` with two new alerts: `CortexRulerTooManyFailedPushes` and `CortexRulerTooManyFailedQueries`. #347
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. #317
 * [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. #324
 * [ENHANCEMENT] Dashboards: defined container functions for common resources panels: containerDiskWritesPanel, containerDiskReadsPanel, containerDiskSpaceUtilization. #331

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -541,7 +541,7 @@
           },
           annotations: {
             message: |||
-              Cortex Ruler {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% write errors.
+              Cortex Ruler {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
             |||,
           },
         },
@@ -560,7 +560,7 @@
           },
           annotations: {
             message: |||
-              Cortex Ruler {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% write errors.
+              Cortex Ruler {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
             |||,
           },
         },

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -163,7 +163,7 @@ Each rule evaluation may fail due to many reasons, eg. due to invalid PromQL exp
 There is a category of errors that is more important: errors due to failure to read data from store-gateways or ingesters. These errors would result in 500 when run from querier. This alert fires if there is too many of such failures.
 
 How to **fix**:
-- Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that rule logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways. 
+- Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that rule logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways.
 
 ### CortexRulerMissedEvaluations
 

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -152,7 +152,7 @@ In general, pushing samples can fail due to problems with Cortex operations (eg.
 This alert fires only for first kind of problems, and not for problems caused by limits or invalid rules.
 
 How to **fix**:
-- Investigate the ruler logs to find out the reason why ruler cannot write samples.
+- Investigate the ruler logs to find out the reason why ruler cannot write samples. Note that ruler logs all push errors, including "user errors", but those are not causing the alert to fire. Focus on problems with ingesters.
 
 ### CortexRulerTooManyFailedQueries
 
@@ -163,7 +163,7 @@ Each rule evaluation may fail due to many reasons, eg. due to invalid PromQL exp
 There is a category of errors that is more important: errors due to failure to read data from store-gateways or ingesters. These errors would result in 500 when run from querier. This alert fires if there is too many of such failures.
 
 How to **fix**:
-- Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that rule logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways.
+- Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that ruler logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways.
 
 ### CortexRulerMissedEvaluations
 

--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -144,9 +144,26 @@ More information:
 
 This alert occurs when a ruler is unable to validate whether or not it should claim ownership over the evaluation of a rule group. The most likely cause is that one of the rule ring entries is unhealthy. If this is the case proceed to the ring admin http page and forget the unhealth ruler. The other possible cause would be an error returned the ring client. If this is the case look into debugging the ring based on the in-use backend implementation.
 
-### CortexRulerFailedEvaluations
+### CortexRulerTooManyFailedPushes
 
-_TODO: this playbook has not been written yet._
+This alert fires when rulers cannot push new samples (result of rule evaluation) to ingesters.
+
+In general, pushing samples can fail due to problems with Cortex operations (eg. too many ingesters have crashed, and ruler cannot write samples to them), or due to problems with resulting data (eg. user hitting limit for number of series, out of order samples, etc.).
+This alert fires only for first kind of problems, and not for problems caused by limits or invalid rules.
+
+How to **fix**:
+- Investigate the ruler logs to find out the reason why ruler cannot write samples.
+
+### CortexRulerTooManyFailedQueries
+
+This alert fires when rulers fail to evaluate rule queries.
+
+Each rule evaluation may fail due to many reasons, eg. due to invalid PromQL expression, or query hits limits on number of chunks. These are "user errors", and this alert ignores them.
+
+There is a category of errors that is more important: errors due to failure to read data from store-gateways or ingesters. These errors would result in 500 when run from querier. This alert fires if there is too many of such failures.
+
+How to **fix**:
+- Investigate the ruler logs to find out the reason why ruler cannot evaluate queries. Note that rule logs rule evaluation errors even for "user errors", but those are not causing the alert to fire. Focus on problems with ingesters or store-gateways. 
 
 ### CortexRulerMissedEvaluations
 


### PR DESCRIPTION
**What this PR does**: This PR replaces `CortexRulerFailedEvaluations` alert with two new alerts: `CortexRulerTooManyFailedPushes` and `CortexRulerTooManyFailedQueries`. Note that second alert is only marked as "warning" for now, until https://github.com/cortexproject/cortex/issues/4333 is fixed.

This PR also adds playbooks for these two alerts.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
