### PR TITLE
Aded object storage metrics for Ruler and Alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## master / unreleased
 
-* [ENHANCEMENT] Cortex-mixin: Include `cortex-gw-internal` naming variation in default `gateway` job names. #328
 * [CHANGE] `namespace` template variable in dashboards now only selects namespaces for selected clusters. #311
 * [CHANGE] Alertmanager: mounted overrides configmap to alertmanager too. #315
 * [CHANGE] Memcached: upgraded memcached from `1.5.17` to `1.6.9`. #316
@@ -22,6 +21,9 @@
 * [CHANGE] Removed `CortexQuerierCapacityFull` alert. #342
 * [CHANGE] Changes blocks storage alerts to group metrics by the configured `cluster_labels` (supporting the deprecated `alert_aggregation_labels`). #351
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. #317
+* [ENHANCEMENT] Cortex-mixin: Include `cortex-gw-internal` naming variation in default `gateway` job names. #328
+* [ENHANCEMENT] Ruler dashboard: added object storage metrics. #354
+* [ENHANCEMENT] Alertmanager dashboard: added object storage metrics. #354
 * [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. #324
 * [ENHANCEMENT] Dashboards: defined container functions for common resources panels: containerDiskWritesPanel, containerDiskReadsPanel, containerDiskSpaceUtilization. #331
 * [ENHANCEMENT] cortex-mixin: Added `alert_excluded_routes` config to exclude specific routes from alerts. #338

--- a/cortex-mixin/dashboards/alertmanager.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager.libsonnet
@@ -83,5 +83,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency') +
         utils.latencyRecordingRulePanel('cortex_request_duration_seconds', $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', 'api_v1_alerts|alertmanager')])
       )
+    )
+    .addRows(
+      $.getObjectStoreRows('Alertmanager Configuration Object Store (Alertmanager accesses)', 'alertmanager-storage')
     ),
 }

--- a/cortex-mixin/dashboards/ruler.libsonnet
+++ b/cortex-mixin/dashboards/ruler.libsonnet
@@ -248,5 +248,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
           '{{ user }}'
         )
       )
+    )
+    .addRows(
+      $.getObjectStoreRows('Ruler Configuration Object Store (Ruler accesses)', 'ruler-storage')
     ),
 }


### PR DESCRIPTION
**What this PR does**:
The Ruler and Alertmanager keeps the config in the object storage, but we don't show the object storage metrics in the Ruler and Alertmanager dashboard. This PR fixes it.

Example:

![Screenshot 2021-07-06 at 11 38 53](https://user-images.githubusercontent.com/1701904/124579119-20dbf200-de4f-11eb-86b6-a39e762f39d0.png)

![Screenshot 2021-07-06 at 11 38 40](https://user-images.githubusercontent.com/1701904/124579128-233e4c00-de4f-11eb-83e4-a123c7a34d01.png)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
