### PR TITLE
Reduce ingester gRPC max concurrent streams to 10,000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [CHANGE] Removed `CortexCacheRequestErrors` alert. This alert was not working because the legacy Cortex cache client instrumentation doesn't track errors. #346
 * [CHANGE] Removed `CortexQuerierCapacityFull` alert. #342
 * [CHANGE] Changes blocks storage alerts to group metrics by the configured `cluster_labels` (supporting the deprecated `alert_aggregation_labels`). #351
+* [CHANGE] Reduce gRPC max concurrent streams to 10,000. #355
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. #317
 * [ENHANCEMENT] Added documentation text panels and descriptions to reads and writes dashboards. #324
 * [ENHANCEMENT] Dashboards: defined container functions for common resources panels: containerDiskWritesPanel, containerDiskReadsPanel, containerDiskSpaceUtilization. #331

--- a/cortex/ingester.libsonnet
+++ b/cortex/ingester.libsonnet
@@ -31,7 +31,7 @@
       'ingester.max-series-per-query': $._config.limits.max_series_per_query,
       'ingester.max-samples-per-query': $._config.limits.max_samples_per_query,
       'runtime-config.file': '/etc/cortex/overrides.yaml',
-      'server.grpc-max-concurrent-streams': 100000,
+      'server.grpc-max-concurrent-streams': 10000,
       'server.grpc-max-send-msg-size-bytes': 10 * 1024 * 1024,
       'server.grpc-max-recv-msg-size-bytes': 10 * 1024 * 1024,
     } + (


### PR DESCRIPTION
**What this PR does**:
Reduce the limit which governs the number of server calls that gRPC will run in parallel. Beyond this limit, requests will queue in the caller.

While parallelism helps to improve throughput, it is unrealistic that 100,000 operations would be able to proceed at once, considering typical CPU core counts, locking, etc.

Even 10,000 is probably too high, but changing the limit by more than one order of magnitude also seemed rash.

**Checklist**
- [x] `CHANGELOG.md` updated
