### PR TITLE
Increased CortexIngesterReachingSeriesLimit critical alert threshold from 80% to 85%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [CHANGE] Removed `CortexCacheRequestErrors` alert. This alert was not working because the legacy Cortex cache client instrumentation doesn't track errors. #346
 * [CHANGE] Removed `CortexQuerierCapacityFull` alert. #342
 * [CHANGE] Changes blocks storage alerts to group metrics by the configured `cluster_labels` (supporting the deprecated `alert_aggregation_labels`). #351
+* [CHANGE] Increased `CortexIngesterReachingSeriesLimit` critical alert threshold from 80% to 85%. #363
 * [ENHANCEMENT] cortex-mixin: Make `cluster_namespace_deployment:kube_pod_container_resource_requests_{cpu_cores,memory_bytes}:sum` backwards compatible with `kube-state-metrics` v2.0.0. #317
 * [ENHANCEMENT] Cortex-mixin: Include `cortex-gw-internal` naming variation in default `gateway` job names. #328
 * [ENHANCEMENT] Ruler dashboard: added object storage metrics. #354

--- a/cortex-mixin/alerts/alerts.libsonnet
+++ b/cortex-mixin/alerts/alerts.libsonnet
@@ -274,7 +274,7 @@
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
                 and ignoring (limit)
                 (cortex_ingester_instance_limits{limit="max_series"} > 0)
-            ) > 0.8
+            ) > 0.85
           |||,
           'for': '5m',
           labels: {


### PR DESCRIPTION
**What this PR does**:
The `CortexIngesterReachingSeriesLimit` alert currently has two threshold:
- warning alert: > 70%
- critical alert: > 80%

The warning alert is currently discussed in https://github.com/grafana/cortex-jsonnet/pull/362 while this PR is focusing on the critical alert.

What we've learned from production about ingesters reaching series limit:
- Series growth is typically slow and the alert fires way before we get even close to the limit (eg. in a Cortex cluster with 50 ingesters and limit of 2.5M / ingester, the ingesters in-memory series grow by 1% every 1.2M series)
- In case of emergency, it's very quick to increase the max series limit, since it's part of the runtime config (no ingesters restart is required)

Because of this, I would propose to fire the critical alert once we reach the 85% utilization (instead of the current 80% threshold). This will still leave us a 15% room before hitting the limit, which typically gives us enough time to address without any customer-facing disruption.

This change, together with the change we're doing in #362, should help to improve `CortexIngesterReachingSeriesLimit` alert to fire only when there's actually an action to take.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
