### PR TITLE
Create another tier with 300K active series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Added `CortexMemcachedRequestErrors` alert. #346
 * [ENHANCEMENT] Ruler dashboard: added "Per route p99 latency" panel in the "Configuration API" row. #353
 * [ENHANCEMENT] Increased the `for` duration of the `CortexIngesterReachingSeriesLimit` warning alert to 3h. #362
+* [ENHANCEMENT] Added a new tier (`medium_small_user`) so we have another tier between 100K and 1Mil active series. #364
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [BUGFIX] Alertmanager: fixed `--alertmanager.cluster.peers` CLI flag passed to alertmanager when HA is enabled. #329
 * [BUGFIX] Fixed `CortexInconsistentRuntimeConfig` metric. #335

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -328,6 +328,25 @@
         ruler_max_rule_groups_per_tenant: 20,
       },
 
+      medium_small_user:: {
+        max_series_per_user: 0,  // Disabled in favour of the max global limit
+        max_series_per_metric: 0,  // Disabled in favour of the max global limit
+
+        // Our limit should be 100k, but we need some room of about ~50% to take rollouts into account
+        max_global_series_per_user: 300000,
+        max_global_series_per_metric: 30000,
+
+        max_series_per_query: 100000,
+        max_samples_per_query: 1000000,
+
+        ingestion_rate: 30000,
+        ingestion_burst_size: 300000,
+
+        // 375 rules
+        ruler_max_rules_per_rule_group: 15,
+        ruler_max_rule_groups_per_tenant: 25,
+      },
+
       small_user:: {
         max_series_per_metric: 0,  // Disabled in favour of the max global limit
         max_series_per_user: 0,  // Disabled in favour of the max global limit


### PR DESCRIPTION
The other tiers have a 3x jump except when we go from 100K to 1Mil. I
think we should have a 3x jump for the first tier too.

I am open to better suggestions for the name.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
