### PR TITLE
Fix scaling dashboard to work on multi-zone ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [BUGFIX] Alertmanager: fixed `--alertmanager.cluster.peers` CLI flag passed to alertmanager when HA is enabled. #329
 * [BUGFIX] Fixed `CortexInconsistentRuntimeConfig` metric. #335
+* [BUGFIX] Fixed scaling dashboard to correctly work when a Cortex service deployment spans across multiple zones (a zone is expected to have the `zone-[a-z]` suffix). #365
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -80,10 +80,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               )
               or
               sum by (cluster, namespace, deployment) (
-                label_replace(
-                  label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*)"),
-                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
-                )
+                label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
               )
             |||,
           },

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -69,12 +69,21 @@ local utils = import 'mixin-utils/utils.libsonnet';
         rules: [
           {
             // Convenience rule to get the number of replicas for both a deployment and a statefulset.
+            // Multi-zone deployments are grouped together removing the "zone-X" suffix.
             record: 'cluster_namespace_deployment:actual_replicas:count',
             expr: |||
-              sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas)
-                or
               sum by (cluster, namespace, deployment) (
-                label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*)")
+                label_replace(
+                  kube_deployment_spec_replicas,
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                )
+              )
+              or
+              sum by (cluster, namespace, deployment) (
+                label_replace(
+                  label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*)"),
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                )
               )
             |||,
           },
@@ -188,7 +197,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             expr: |||
               ceil(
                 (sum by (cluster, namespace) (
-                  cortex_ingester_tsdb_storage_blocks_bytes{job=~".+/ingester"}
+                  cortex_ingester_tsdb_storage_blocks_bytes{job=~".+/ingester.*"}
                 ) / 4)
                   /
                 avg by (cluster, namespace) (
@@ -199,18 +208,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
           {
             // Convenience rule to get the CPU utilization for both a deployment and a statefulset.
+            // Multi-zone deployments are grouped together removing the "zone-X" suffix.
             record: 'cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate',
             expr: |||
               sum by (cluster, namespace, deployment) (
                 label_replace(
-                  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate,
-                  "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  label_replace(
+                    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate,
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  ),
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                 )
               )
             |||,
           },
           {
             // Convenience rule to get the CPU request for both a deployment and a statefulset.
+            // Multi-zone deployments are grouped together removing the "zone-X" suffix.
             record: 'cluster_namespace_deployment:kube_pod_container_resource_requests_cpu_cores:sum',
             expr: |||
               # This recording rule is made compatible with the breaking changes introduced in kube-state-metrics v2
@@ -223,8 +237,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
               (
                 sum by (cluster, namespace, deployment) (
                   label_replace(
-                    kube_pod_container_resource_requests_cpu_cores,
-                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    label_replace(
+                      kube_pod_container_resource_requests_cpu_cores,
+                      "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    ),
+                    "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
               )
@@ -234,8 +251,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
               (
                 sum by (cluster, namespace, deployment) (
                   label_replace(
-                    kube_pod_container_resource_requests{resource="cpu"},
-                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    label_replace(
+                      kube_pod_container_resource_requests{resource="cpu"},
+                      "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    ),
+                    "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
               )
@@ -261,18 +281,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
           {
             // Convenience rule to get the Memory utilization for both a deployment and a statefulset.
+            // Multi-zone deployments are grouped together removing the "zone-X" suffix.
             record: 'cluster_namespace_deployment:container_memory_usage_bytes:sum',
             expr: |||
               sum by (cluster, namespace, deployment) (
                 label_replace(
-                  container_memory_usage_bytes,
-                  "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  label_replace(
+                    container_memory_usage_bytes,
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  ),
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                 )
               )
             |||,
           },
           {
             // Convenience rule to get the Memory request for both a deployment and a statefulset.
+            // Multi-zone deployments are grouped together removing the "zone-X" suffix.
             record: 'cluster_namespace_deployment:kube_pod_container_resource_requests_memory_bytes:sum',
             expr: |||
               # This recording rule is made compatible with the breaking changes introduced in kube-state-metrics v2
@@ -285,8 +310,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
               (
                 sum by (cluster, namespace, deployment) (
                   label_replace(
-                    kube_pod_container_resource_requests_memory_bytes,
-                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    label_replace(
+                      kube_pod_container_resource_requests_memory_bytes,
+                      "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    ),
+                    "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
               )
@@ -296,8 +324,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
               (
                 sum by (cluster, namespace, deployment) (
                   label_replace(
-                    kube_pod_container_resource_requests{resource="memory"},
-                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    label_replace(
+                      kube_pod_container_resource_requests{resource="memory"},
+                      "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                    ),
+                    "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
               )

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -75,6 +75,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
               sum by (cluster, namespace, deployment) (
                 label_replace(
                   kube_deployment_spec_replicas,
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
                   "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                 )
               )
@@ -214,6 +216,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                     node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate,
                     "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
                   "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                 )
               )
@@ -238,6 +242,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                       kube_pod_container_resource_requests_cpu_cores,
                       "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                     ),
+                    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                    # always matches everything and the (optional) zone is not removed.
                     "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
@@ -252,6 +258,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                       kube_pod_container_resource_requests{resource="cpu"},
                       "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                     ),
+                    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                    # always matches everything and the (optional) zone is not removed.
                     "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
@@ -287,6 +295,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                     container_memory_usage_bytes,
                     "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
                   "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                 )
               )
@@ -311,6 +321,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                       kube_pod_container_resource_requests_memory_bytes,
                       "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                     ),
+                    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                    # always matches everything and the (optional) zone is not removed.
                     "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )
@@ -325,6 +337,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                       kube_pod_container_resource_requests{resource="memory"},
                       "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                     ),
+                    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                    # always matches everything and the (optional) zone is not removed.
                     "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
                   )
                 )


### PR DESCRIPTION
**What this PR does**:
We have some clusters running Cortex ingesters in multi-zone. Each zone is a StatefulSet whose name matches this pattern `ingester-zone-[a-z]`, so their pod names are like `ingester-zone-a-0` or `ingester-zone-b-1`. All dashboards work correctly except for the scaling dashboard and this PR proposes a fix for that.

Reason why the scaling dashboard doesn't work is that some recording rule computes the expected scaling value summing up all ingesters (eg. `cluster_namespace_deployment_reason:required_replicas:count`) while the actual usage metrics are grouped by deployment/statefulset name, so they're splitted by zone.

I think the desired behaviour is summing up all ingesters, regardless their zone, so in this PR I'm proposing to remove the `-zone-[a-z]` suffix (if found) when we compute the `deployment` name.

A couple of notes:
- I manually tested all updated recording rules and should work
- I had to wrap with another `label_replace()` due to conflicts with regex greediness

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
