### PR TITLE
Fix rollout dashboard to work with multi-zone deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] Alertmanager: fixed `--alertmanager.cluster.peers` CLI flag passed to alertmanager when HA is enabled. #329
 * [BUGFIX] Fixed `CortexInconsistentRuntimeConfig` metric. #335
 * [BUGFIX] Fixed scaling dashboard to correctly work when a Cortex service deployment spans across multiple zones (a zone is expected to have the `zone-[a-z]` suffix). #365
+* [BUGFIX] Fixed rollout progress dashboard to correctly work when a Cortex service deployment spans across multiple zones (a zone is expected to have the `zone-[a-z]` suffix). #366
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex-mixin/dashboards/rollout-progress.libsonnet
+++ b/cortex-mixin/dashboards/rollout-progress.libsonnet
@@ -76,6 +76,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ||| % config,
         ], legends=[
           '{{cortex_service}}',
+          '{{cortex_service}}',
         ], thresholds=[
           { color: 'yellow', value: null },
           { color: 'yellow', value: 0.999 },


### PR DESCRIPTION
**What this PR does**:
This PR fixes the "Rollout progress" panel of the "Rollout progress" dashboard, to correctly work when a cortex service is deployed across multiples zones.

Notes:
- Follows the same approach took in #365
- I've manually tested the updated queries and should work correctly.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
