### PR TITLE
Added functions to create query-frontend and querier deployments

### DIFF
--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -57,11 +57,14 @@
 
   querier_deployment_labels: {},
 
-  querier_deployment:
-    deployment.new('querier', $._config.querier.replicas, [$.querier_container], $.querier_deployment_labels) +
+  newQuerierDeployment(name, container)::
+    deployment.new(name, $._config.querier.replicas, [container], $.querier_deployment_labels) +
     $.util.antiAffinity +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
     $.storage_config_mixin,
+
+  querier_deployment:
+    self.newQuerierDeployment('querier', $.querier_container),
 
   local service = $.core.v1.service,
 

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -68,14 +68,16 @@
 
   local deployment = $.apps.v1.deployment,
 
-  query_frontend_deployment:
-    deployment.new('query-frontend', $._config.queryFrontend.replicas, [$.query_frontend_container]) +
+  newQueryFrontendDeployment(name, container)::
+    deployment.new(name, $._config.queryFrontend.replicas, [container]) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
     $.util.antiAffinity +
     // inject storage schema in order to know what/how to shard
     if $._config.queryFrontend.sharded_queries_enabled then
       $.storage_config_mixin
     else {},
+
+  query_frontend_deployment: self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container),
 
   local service = $.core.v1.service,
 


### PR DESCRIPTION
**What this PR does**:
We have an use case for which we need to create a secondary pool of query-frontends and queriers. Similary to the utility function `newIngesterStatefulSet()` that we've added in the path, in this PR I'm proposing to add 2 functions create query-frontend and querier deployments respectively.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
