### PR TITLE
fix(rules): upstream recording rule switched to sum_irate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [BUGFIX] Fixed rollout progress dashboard to correctly work when a Cortex service deployment spans across multiple zones (a zone is expected to have the `zone-[a-z]` suffix). #366
 * [BUGFIX] Fixed rollout progress dashboard to include query-scheduler too. #376
 * [BUGFIX] Fixed `-distributor.extend-writes` setting on ruler when `unregister_ingesters_on_shutdown` is disabled. #369
+* [BUGFIX] Upstream recording rule `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` renamed. #379
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -213,7 +213,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               sum by (cluster, namespace, deployment) (
                 label_replace(
                   label_replace(
-                    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate,
+                    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate,
                     "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
                   # The question mark in "(.*?)" is used to make it non-greedy, otherwise it


### PR DESCRIPTION
ref: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/619

**What this PR does**:
Upstream recording rule switched to sum_irate, this was reflected in the recording rule name.

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
