### PR TITLE
Make the overrides metric name configurable.

### DIFF
--- a/cortex-mixin/recording_rules.libsonnet
+++ b/cortex-mixin/recording_rules.libsonnet
@@ -6,6 +6,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     max_samples_per_sec_per_ingester: 80e3,
     max_samples_per_sec_per_distributor: 240e3,
     limit_utilisation_target: 0.6,
+    cortex_overrides_metric: 'cortex_overrides',
   } + $._config + $._group_config,
   prometheusRules+:: {
     groups+: [
@@ -114,7 +115,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
             expr: |||
               ceil(
-                sum by (cluster, namespace) (cortex_overrides{limit_name="ingestion_rate"})
+                sum by (cluster, namespace) (%(cortex_overrides_metric)s{limit_name="ingestion_rate"})
                 * %(limit_utilisation_target)s / %(max_samples_per_sec_per_distributor)s
               )
             ||| % _config,
@@ -166,7 +167,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
             expr: |||
               ceil(
-                sum by (cluster, namespace) (cortex_overrides{limit_name="max_global_series_per_user"})
+                sum by (cluster, namespace) (%(cortex_overrides_metric)s{limit_name="max_global_series_per_user"})
                 * 3 * %(limit_utilisation_target)s / %(max_series_per_ingester)s
               )
             ||| % _config,
@@ -181,7 +182,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
             expr: |||
               ceil(
-                sum by (cluster, namespace) (cortex_overrides{limit_name="ingestion_rate"})
+                sum by (cluster, namespace) (%(cortex_overrides_metric)s{limit_name="ingestion_rate"})
                 * %(limit_utilisation_target)s / %(max_samples_per_sec_per_ingester)s
               )
             ||| % _config,


### PR DESCRIPTION
We (Grafana Labs) are about to put in a new system to control and export
data about limits and we'll need to use a different name. This shouldn't
affect our OSS users.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>