### PR TITLE
Add rate back to Alertmanager dashboard initial syncs panel.

### DIFF
--- a/cortex-mixin/dashboards/alertmanager.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager.libsonnet
@@ -152,12 +152,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Sharding Initial State Sync')
       .addPanel(
-        $.panel('Tenant initial sync outcomes') +
+        $.panel('Initial syncs /sec') +
         $.queryPanel(
-          'sum by(outcome) (cortex_alertmanager_state_initial_sync_completed_total{%s})' % $.jobMatcher('alertmanager'),
+          'sum by(outcome) (rate(cortex_alertmanager_state_initial_sync_completed_total{%s}[$__rate_interval]))' % $.jobMatcher('alertmanager'),
           '{{outcome}}'
-        ) +
-        $.stack
+        ) + {
+          targets: [
+            target {
+              interval: '1m',
+            }
+            for target in super.targets
+          ],
+        }
       )
       .addPanel(
         $.panel('Initial sync duration') +


### PR DESCRIPTION
**What this PR does**:

The metric in fact does act like a counter due to soft deletion of the
per-user registry when the user is unconfigured (e.g. moved to another
instance or configuration deleted).

