### PR TITLE
Fix `compactor_blocks_retention_period` type in `extra_small_user`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [BUGFIX] Fixed rollout progress dashboard to include query-scheduler too. #376
 * [BUGFIX] Fixed `-distributor.extend-writes` setting on ruler when `unregister_ingesters_on_shutdown` is disabled. #369
 * [BUGFIX] Upstream recording rule `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` renamed. #379
+* [BUGFIX] Treat `compactor_blocks_retention_period` type as string rather than int.#395
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -358,7 +358,7 @@
         ruler_max_rule_groups_per_tenant: 20,
 
         // No retention for now.
-        compactor_blocks_retention_period: 0,
+        compactor_blocks_retention_period: '0',
       },
 
       medium_small_user:: {


### PR DESCRIPTION
The actual type of `compactor_blocks_retention_period` is `model.Duration`. Which comes
from prometheus `common` package.

The problem is that `model.Duration` have custom JSON unmarshal which treat the incoming
value as string.
https://github.com/prometheus/common/blob/main/model/time.go#L276

So setting it as integer, won't work when unmarshalling with JSON.

NOTE: This won't be an issue for YamlUnmarshal, as it always treating it as string (even
though you put it as integer)
https://github.com/prometheus/common/blob/main/model/time.go#L307

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes NA

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
