### PR TITLE
Add queryEngineConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
   * `CortexAlertmanagerInitialSyncFailed`
 * [ENHANCEMENT] Add support for Azure storage in Alertmanager configuration. #381
 * [ENHANCEMENT] Add support for running Alertmanager in sharding mode. #394
+* [ENHANCEMENT] Allow to customize PromQL engine settings via `queryEngineConfig`. #399
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [BUGFIX] Alertmanager: fixed `--alertmanager.cluster.peers` CLI flag passed to alertmanager when HA is enabled. #329
 * [BUGFIX] Fixed `CortexInconsistentRuntimeConfig` metric. #335

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -196,7 +196,7 @@
       ) else {}
     ),
 
-    // Shared between the Ruler and Querier
+    // Querier component config (shared between the ruler and querier).
     queryConfig: {
       'runtime-config.file': '/etc/cortex/overrides.yaml',
 
@@ -238,6 +238,11 @@
         }
       else {}
     ),
+
+    // PromQL query engine config (shared between all services running PromQL engine, like the ruler and querier).
+    queryEngineConfig: {
+      // Keep it even if empty, to allow downstream projects to easily configure it.
+    },
 
     ringConfig: {
       'consul.hostname': 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -8,6 +8,7 @@
     $._config.storageConfig +
     $._config.blocksStorageConfig +
     $._config.queryConfig +
+    $._config.queryEngineConfig +
     $._config.distributorConfig +
     {
       target: 'querier',

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -8,6 +8,7 @@
     $._config.storageConfig +
     $._config.blocksStorageConfig +
     $._config.queryConfig +
+    $._config.queryEngineConfig +
     $._config.distributorConfig +
     $._config.rulerClientConfig +
     $._config.rulerLimitsConfig +


### PR DESCRIPTION
**What this PR does**:
I would like to add `queryEngineConfig` to let downstream projects to have a single place where to put PromQL engine config overrides.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
