### PR TITLE
Use `$._config.job_names.gateway` in resources dashboards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [BUGFIX] Fixed `-distributor.extend-writes` setting on ruler when `unregister_ingesters_on_shutdown` is disabled. #369
 * [BUGFIX] Upstream recording rule `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` renamed. #379
 * [BUGFIX] Treat `compactor_blocks_retention_period` type as string rather than int.#395
+* [BUGFIX] Fixed writes/reads/alertmanager resources dashboards to use `$._config.job_names.gateway`. #403
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager-resources.libsonnet
@@ -7,10 +7,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'cortex-gw'),
+        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
       )
       .addPanel(
         $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -145,8 +145,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   containerCPUUsagePanel(title, containerName)::
     $.panel(title) +
     $.queryPanel([
-      'sum by(%s) (rate(container_cpu_usage_seconds_total{%s,container="%s"}[$__rate_interval]))' % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
-      'min(container_spec_cpu_quota{%s,container="%s"} / container_spec_cpu_period{%s,container="%s"})' % [$.namespaceMatcher(), containerName, $.namespaceMatcher(), containerName],
+      'sum by(%s) (rate(container_cpu_usage_seconds_total{%s,container=~"%s"}[$__rate_interval]))' % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
+      'min(container_spec_cpu_quota{%s,container=~"%s"} / container_spec_cpu_period{%s,container=~"%s"})' % [$.namespaceMatcher(), containerName, $.namespaceMatcher(), containerName],
     ], ['{{%s}}' % $._config.per_instance_label, 'limit']) +
     {
       seriesOverrides: [
@@ -164,8 +164,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
     $.queryPanel([
       // We use "max" instead of "sum" otherwise during a rolling update of a statefulset we will end up
       // summing the memory of the old instance/pod (whose metric will be stale for 5m) to the new instance/pod.
-      'max by(%s) (container_memory_working_set_bytes{%s,container="%s"})' % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
-      'min(container_spec_memory_limit_bytes{%s,container="%s"} > 0)' % [$.namespaceMatcher(), containerName],
+      'max by(%s) (container_memory_working_set_bytes{%s,container=~"%s"})' % [$._config.per_instance_label, $.namespaceMatcher(), containerName],
+      'min(container_spec_memory_limit_bytes{%s,container=~"%s"} > 0)' % [$.namespaceMatcher(), containerName],
     ], ['{{%s}}' % $._config.per_instance_label, 'limit']) +
     {
       seriesOverrides: [

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -7,10 +7,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'cortex-gw'),
+        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
       )
       .addPanel(
         $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -7,10 +7,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('Gateway')
       .addPanel(
-        $.containerCPUUsagePanel('CPU', 'cortex-gw'),
+        $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
       )
       .addPanel(
-        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', $._config.job_names.gateway),
       )
       .addPanel(
         $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.gateway),


### PR DESCRIPTION
This fixes panels where `cortex-gw` was hardcoded.
