### PR TITLE
Modify query for calculating replica count for ingesters in runbook

### DIFF
--- a/cortex-mixin/docs/playbooks.md
+++ b/cortex-mixin/docs/playbooks.md
@@ -565,7 +565,7 @@ How to **fix**:
 - Scale up ingesters
   - To compute the desired number of ingesters to satisfy the average samples rate you can run the following query, replacing `<namespace>` with the namespace to analyse and `<target>` with the target number of samples/sec per ingester (check out the alert threshold to see the current target):
     ```
-    sum(rate(cortex_ingester_ingested_samples_total{namespace="<namespace>"}[$__rate_interval])) / (<target> * 0.9)
+    sum by (__tenant_id__) (rate(cortex_ingester_ingested_samples_total{namespace="<namespace>"}[$__rate_interval])) / (<target> * 0.9)
     ```
 
 ### CortexAllocatingTooMuchMemory


### PR DESCRIPTION
**What this PR does**: Modify query for calculating replica count for ingesters in runbook 

**Why:** We're ingesting the same metrics of our GEM cluster twice - under two different tenants. This ends up throwing off the query in the runbook.

**Which issue(s) this PR fixes**: n/a but relates to https://github.com/grafana/deployment_tools/pull/17784 

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
