### PR TITLE
Further document ingester_stream_chunks_when_using_blocks parameter

### DIFF
--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -476,6 +476,7 @@
     query_scheduler_enabled: false,
 
     // Enables streaming of chunks from ingesters using blocks.
+    // Changing it will not cause new rollout of ingesters, as it gets passed to them via runtime-config.
     ingester_stream_chunks_when_using_blocks: true,
 
     // Ingester limits are put directly into runtime config, if not null. Available limits:


### PR DESCRIPTION
**What this PR does**:
Document `ingester_stream_chunks_when_using_blocks` some more, wrt. how changing it won't cause ingesters to get re-rolled out.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
