### PR TITLE
Add options to disable anti-affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@
 * [ENHANCEMENT] Use alertmanager jobname for alertmanager dashboard panels #411
 * [ENHANCEMENT] Added `CortexDistributorReachingInflightPushRequestLimit` alert. #408
 * [ENHANCEMENT] Define Azure object storage ruler args. #416
+* [ENHANCEMENT] Added the following config options to allow to schedule multiple replicas of the same service on the same node: #418
+  * `cortex_distributor_allow_multiple_replicas_on_same_node`
+  * `cortex_ruler_allow_multiple_replicas_on_same_node`
+  * `cortex_querier_allow_multiple_replicas_on_same_node`
+  * `cortex_query_frontend_allow_multiple_replicas_on_same_node`
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [BUGFIX] Alertmanager: fixed `--alertmanager.cluster.peers` CLI flag passed to alertmanager when HA is enabled. #329
 * [BUGFIX] Fixed `CortexInconsistentRuntimeConfig` metric. #335

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -20,6 +20,12 @@
     // 2. Ensure ingester ID is preserved during rollouts
     unregister_ingesters_on_shutdown: true,
 
+    // Controls whether multiple pods for the same service can be scheduled on the same node.
+    cortex_distributor_allow_multiple_replicas_on_same_node: false,
+    cortex_ruler_allow_multiple_replicas_on_same_node: false,
+    cortex_querier_allow_multiple_replicas_on_same_node: false,
+    cortex_query_frontend_allow_multiple_replicas_on_same_node: false,
+
     // schema is used to generate the storage schema yaml file used by
     // the Cortex chunks storage:
     // - More information: https://github.com/cortexproject/cortex/pull/1072

--- a/cortex/distributor.libsonnet
+++ b/cortex/distributor.libsonnet
@@ -56,7 +56,7 @@
 
   distributor_deployment:
     deployment.new('distributor', 3, [$.distributor_container], $.distributor_deployment_labels) +
-    $.util.antiAffinity +
+    (if $._config.cortex_distributor_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex'),
 
   local service = $.core.v1.service,

--- a/cortex/querier.libsonnet
+++ b/cortex/querier.libsonnet
@@ -56,7 +56,7 @@
 
   newQuerierDeployment(name, container)::
     deployment.new(name, $._config.querier.replicas, [container], $.querier_deployment_labels) +
-    $.util.antiAffinity +
+    (if $._config.cortex_querier_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
     $.storage_config_mixin,
 

--- a/cortex/query-frontend.libsonnet
+++ b/cortex/query-frontend.libsonnet
@@ -52,7 +52,7 @@
   newQueryFrontendDeployment(name, container)::
     deployment.new(name, $._config.queryFrontend.replicas, [container]) +
     $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
-    $.util.antiAffinity,
+    (if $._config.cortex_query_frontend_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity),
 
   query_frontend_deployment: self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container),
 

--- a/cortex/ruler.libsonnet
+++ b/cortex/ruler.libsonnet
@@ -54,7 +54,7 @@
       deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
       deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(600) +
-      $.util.antiAffinity +
+      (if $._config.cortex_ruler_allow_multiple_replicas_on_same_node then {} else $.util.antiAffinity) +
       $.util.configVolumeMount($._config.overrides_configmap, '/etc/cortex') +
       $.storage_config_mixin
     else {},


### PR DESCRIPTION
**What this PR does**:
In case we're running a very large number of replicas for a given cluster, it may be desiderable to schedule multiple replicas on the same node. In this PR I'm proposing to add options to disable anti-affinity.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
