### PR TITLE
Ruler: Pass `-ruler-storage.s3.endpoint` to ruler when using S3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [BUGFIX] Treat `compactor_blocks_retention_period` type as string rather than int.#395
 * [BUGFIX] Fixed writes/reads/alertmanager resources dashboards to use `$._config.job_names.gateway`. #403
 * [BUGFIX] Span the annotation.message in alerts as YAML multiline strings. #412
+* [BUGFIX] Pass `-ruler-storage.s3.endpoint` to ruler when using S3. #421
 
 ## 1.9.0 / 2021-05-18
 

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -265,6 +265,7 @@
         s3: {
           'ruler-storage.s3.region': $._config.aws_region,
           'ruler-storage.s3.bucket-name': $._config.ruler_storage_bucket_name,
+          'ruler-storage.s3.endpoint': 's3.dualstack.%s.amazonaws.com' % $._config.aws_region,
         },
         azure: {
           'ruler-storage.azure.container-name': $._config.ruler_storage_bucket_name,


### PR DESCRIPTION
This argument is required, without it, the following error appears:

```
no s3 endpoint in config file
```
