### PR TITLE
Fix alertmanager.cluster.listen-address with single replica

### DIFF
--- a/cortex/alertmanager.libsonnet
+++ b/cortex/alertmanager.libsonnet
@@ -50,7 +50,7 @@
     gossip_single_replica: {
       ports: [],
       args: {},
-      flags: ['--alertmanager.cluster.listen-address=""'],
+      flags: ['--alertmanager.cluster.listen-address='],
       service: $.util.serviceFor($.alertmanager_statefulset),
     },
   }[haType],


### PR DESCRIPTION
Looks like this got broken again in some refactoring along the way
Setting the flag to an empty string causes an error on startup:

```
level=error ts=2021-11-29T02:53:40.522651402Z caller=log.go:106 msg="error running cortex" err="address \"\": missing port in address
invalid listen address
github.com/prometheus/alertmanager/cluster.Create
	/__w/cortex/cortex/vendor/github.com/prometheus/alertmanager/cluster/cluster.go:147
github.com/cortexproject/cortex/pkg/alertmanager.NewMultitenantAlertmanager
	/__w/cortex/cortex/pkg/alertmanager/multitenant.go:317
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).initAlertManager
	/__w/cortex/cortex/pkg/cortex/modules.go:723
github.com/grafana/dskit/modules.(*Manager).initModule
	/__w/cortex/cortex/vendor/github.com/grafana/dskit/modules/modules.go:106
github.com/grafana/dskit/modules.(*Manager).InitModuleServices
	/__w/cortex/cortex/vendor/github.com/grafana/dskit/modules/modules.go:78
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run
	/__w/cortex/cortex/pkg/cortex/cortex.go:412
main.main
	/__w/cortex/cortex/cmd/cortex/main.go:195
runtime.main
	/usr/local/go/src/runtime/proc.go:225
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1371
unable to initialize gossip mesh
github.com/cortexproject/cortex/pkg/alertmanager.NewMultitenantAlertmanager
	/__w/cortex/cortex/pkg/alertmanager/multitenant.go:332
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).initAlertManager
	/__w/cortex/cortex/pkg/cortex/modules.go:723
github.com/grafana/dskit/modules.(*Manager).initModule
	/__w/cortex/cortex/vendor/github.com/grafana/dskit/modules/modules.go:106
github.com/grafana/dskit/modules.(*Manager).InitModuleServices
	/__w/cortex/cortex/vendor/github.com/grafana/dskit/modules/modules.go:78
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run
	/__w/cortex/cortex/pkg/cortex/cortex.go:412
main.main
	/__w/cortex/cortex/cmd/cortex/main.go:195
runtime.main
	/usr/local/go/src/runtime/proc.go:225
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1371
error initialising module: alertmanager
github.com/grafana/dskit/modules.(*Manager).initModule
	/__w/cortex/cortex/vendor/github.com/grafana/dskit/modules/modules.go:108
github.com/grafana/dskit/modules.(*Manager).InitModuleServices
	/__w/cortex/cortex/vendor/github.com/grafana/dskit/modules/modules.go:78
github.com/cortexproject/cortex/pkg/cortex.(*Cortex).Run
	/__w/cortex/cortex/pkg/cortex/cortex.go:412
main.main
	/__w/cortex/cortex/cmd/cortex/main.go:195
runtime.main
	/usr/local/go/src/runtime/proc.go:225
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1371"
```
