### PR TITLE
WIP: Add resources for running with dskit kubernetes ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
   * `cortex_ruler_allow_multiple_replicas_on_same_node`
   * `cortex_querier_allow_multiple_replicas_on_same_node`
   * `cortex_query_frontend_allow_multiple_replicas_on_same_node`
+* [ENHANCEMENT] Add support for dskit kubernetes KV store. #423
 * [BUGFIX] Fixed `CortexIngesterHasNotShippedBlocks` alert false positive in case an ingester instance had ingested samples in the past, then no traffic was received for a long period and then it started receiving samples again. #308
 * [BUGFIX] Alertmanager: fixed `--alertmanager.cluster.peers` CLI flag passed to alertmanager when HA is enabled. #329
 * [BUGFIX] Fixed `CortexInconsistentRuntimeConfig` metric. #335

--- a/cortex/config.libsonnet
+++ b/cortex/config.libsonnet
@@ -1,5 +1,6 @@
 {
   _config+: {
+    ringServiceAccountName: 'dskit-ring',
     namespace: error 'must define namespace',
     cluster: error 'must define cluster',
     replication_factor: 3,

--- a/cortex/kubernetes-ring.libsonnet
+++ b/cortex/kubernetes-ring.libsonnet
@@ -1,0 +1,33 @@
+local kausal = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet',
+      deployment = kausal.apps.v1.deployment,
+      policyRule = kausal.rbac.v1.policyRule,
+      role = kausal.rbac.v1.role,
+      roleBinding = kausal.rbac.v1.roleBinding,
+      serviceAccount = kausal.core.v1.serviceAccount,
+      statefulSet = kausal.apps.v1.statefulSet,
+      subject = kausal.rbac.v1.subject;
+
+{
+  kubernetes_ring_service_account:
+    serviceAccount.new($._config.ringServiceAccountName),
+
+  kubernetes_ring_role:
+    role.new($._config.ringServiceAccountName)
+    + role.withRules([
+      policyRule.withApiGroups([''])
+      + policyRule.withResources(['configmaps'])
+      + policyRule.withVerbs(['create', 'list', 'get', 'patch', 'watch']),
+    ]),
+
+  kubernetes_ring_role_binding:
+    roleBinding.new()
+    + roleBinding.metadata.withName($._config.ringServiceAccountName)
+    + roleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io')
+    + roleBinding.roleRef.withKind('Role')
+    + roleBinding.roleRef.withName($._config.ringServiceAccountName)
+    + roleBinding.withSubjects([
+      subject.new()
+      + subject.withName($._config.ringServiceAccountName)
+      + subject.withKind('ServiceAccount'),
+    ]),
+}


### PR DESCRIPTION
**What this PR does**: As part of a hackathon project we added a kubernetes KV provider to dskit. This PR adds a new file `cortex/kubernetes-ring.libsonnet` which provisions the service account, role & role binding needed to run the ring.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
