### PR TITLE
Fix newStoreGatewayStatefulSet() to use input container

### DIFF
--- a/cortex/tsdb.libsonnet
+++ b/cortex/tsdb.libsonnet
@@ -256,7 +256,7 @@
     $.jaeger_mixin,
 
   newStoreGatewayStatefulSet(name, container)::
-    statefulSet.new(name, 3, [$.store_gateway_container], store_gateway_data_pvc) +
+    statefulSet.new(name, 3, [container], store_gateway_data_pvc) +
     statefulSet.mixin.spec.withServiceName(name) +
     statefulSet.mixin.metadata.withNamespace($._config.namespace) +
     statefulSet.mixin.metadata.withLabels({ name: name }) +


### PR DESCRIPTION
**What this PR does**:
In #424 I've introduced `newStoreGatewayStatefulSet()` but it's not using the input `container`. This PR fixes it.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
