### PR TITLE
Update dashboards to support Helm chart deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master / unreleased
 
+* [ENHANCEMENT] Update cortex-mixin to support Cortex deployment from the Helm chart. #361
+
 ## 1.11.0 / 2021-12-30
 
 * [CHANGE] Store gateway: set `-blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency`,

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -7,6 +7,11 @@
     // May contain 'chunks', 'blocks' or both.
     // Enables chunks- or blocks- specific panels and dashboards.
     storage_engine: ['blocks'],
+    
+    // Disable unused panels depending whether a component was installed or not
+    cortex_gw_enabled: false,
+    query_scheduler_enabled: false,
+    ruler_enabled: false,
 
     // For chunks backend, switch for chunk index type.
     // May contain 'bigtable', 'dynamodb' or 'cassandra'.
@@ -47,15 +52,17 @@
     cortex_p99_latency_threshold_seconds: 2.5,
 
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
-    resources_dashboards_enabled: false,
+    resources_dashboards_enabled: true,
 
     // The label used to differentiate between different application instances (i.e. 'pod' in a kubernetes install).
     per_instance_label: 'pod',
 
     // Name selectors for different application instances, using the "per_instance_label".
     instance_names: {
-      compactor: 'compactor.*',
-      alertmanager: 'alertmanager.*',
+      alertmanager: '.*alertmanager.*',
+      compactor: '.*compactor.*',
+      ingester: '.*ingester.*',
+      store_gateway: '.*store-gateway.*',
     },
 
     // The label used to differentiate between different nodes (i.e. servers).

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -7,10 +7,10 @@
     // May contain 'chunks', 'blocks' or both.
     // Enables chunks- or blocks- specific panels and dashboards.
     storage_engine: ['blocks'],
-    
+
     // HTTP URL prefix under which the Prometheus api is available.
     prometheus_http_prefix: 'cortex',
-    
+
     // Disable unused panels depending whether a component was installed or not
     cortex_gw_enabled: false,
     query_scheduler_enabled: false,

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -8,6 +8,9 @@
     // Enables chunks- or blocks- specific panels and dashboards.
     storage_engine: ['blocks'],
     
+    // HTTP URL prefix under which the Prometheus api is available.
+    prometheus_http_prefix: 'cortex',
+    
     // Disable unused panels depending whether a component was installed or not
     cortex_gw_enabled: false,
     query_scheduler_enabled: false,

--- a/cortex-mixin/config.libsonnet
+++ b/cortex-mixin/config.libsonnet
@@ -9,12 +9,12 @@
     storage_engine: ['blocks'],
 
     // HTTP URL prefix under which the Prometheus api is available.
-    prometheus_http_prefix: 'cortex',
+    prometheus_http_prefix: 'prometheus',
 
     // Disable unused panels depending whether a component was installed or not
-    cortex_gw_enabled: false,
-    query_scheduler_enabled: false,
-    ruler_enabled: false,
+    cortex_gw_enabled: true,
+    query_scheduler_enabled: true,
+    ruler_enabled: true,
 
     // For chunks backend, switch for chunk index type.
     // May contain 'bigtable', 'dynamodb' or 'cassandra'.
@@ -55,7 +55,7 @@
     cortex_p99_latency_threshold_seconds: 2.5,
 
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
-    resources_dashboards_enabled: true,
+    resources_dashboards_enabled: false,
 
     // The label used to differentiate between different application instances (i.e. 'pod' in a kubernetes install).
     per_instance_label: 'pod',

--- a/cortex-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/cortex-mixin/dashboards/alertmanager-resources.libsonnet
@@ -4,7 +4,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   'alertmanager-resources.json':
     ($.dashboard('Cortex / Alertmanager Resources') + { uid: '68b66aed90ccab448009089544a8d6c6' })
     .addClusterSelectorTemplates(false)
-    .addRow(
+    .addRowIf(
+      $._config.cortex_gw_enabled,
       $.row('Gateway')
       .addPanel(
         $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
@@ -61,7 +62,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addRow(
       $.row('')
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk Space Utilization', 'alertmanager'),
+        $.containerDiskSpaceUtilization('Disk Space Utilization', $._config.instance_names.alertmanager),
       )
     ),
 }

--- a/cortex-mixin/dashboards/compactor-resources.libsonnet
+++ b/cortex-mixin/dashboards/compactor-resources.libsonnet
@@ -34,7 +34,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerDiskReadsPanel('Disk Reads', 'compactor'),
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk Space Utilization', 'compactor'),
+        $.containerDiskSpaceUtilization('Disk Space Utilization', $._config.instance_names.compactor),
       )
     ) + {
       templating+: {

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -9,6 +9,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
   // - some links that propagate the selectred cluster.
   dashboard(title)::
     super.dashboard(title=title, datasource=$._config.dashboard_datasource) + {
+      refresh: '30s',
+      timezone: 'browser',
+
       addRowIf(condition, row)::
         if condition
         then self.addRow(row)
@@ -73,7 +76,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   namespaceMatcher()::
     if $._config.singleBinary
     then 'job=~"$job"'
-    else 'cluster=~"$cluster", namespace=~"$namespace"',
+    else 'namespace=~"$namespace"',
 
   jobSelector(job)::
     if $._config.singleBinary

--- a/cortex-mixin/dashboards/dashboard-utils.libsonnet
+++ b/cortex-mixin/dashboards/dashboard-utils.libsonnet
@@ -207,15 +207,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       |||
         sum by(%s, %s, device) (
           rate(
-            node_disk_written_bytes_total[$__rate_interval]
+            %s[$__rate_interval]
           )
         )
-        +
-        %s
       ||| % [
         $._config.per_node_label,
         $._config.per_instance_label,
-        $.filterNodeDiskContainer(containerName),
+        $.nodeDiskContainerBytesTotal(containerName, 'writes'),
       ],
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
@@ -228,13 +226,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       |||
         sum by(%s, %s, device) (
           rate(
-            node_disk_read_bytes_total[$__rate_interval]
+            %s[$__rate_interval]
           )
-        ) + %s
+        )
       ||| % [
         $._config.per_node_label,
         $._config.per_instance_label,
-        $.filterNodeDiskContainer(containerName),
+        $.nodeDiskContainerBytesTotal(containerName, 'reads'),
       ],
       '{{%s}} - {{device}}' % $._config.per_instance_label
     ) +
@@ -264,9 +262,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     { yaxes: $.yaxes('percentunit') },
 
   containerLabelMatcher(containerName)::
-    if containerName == 'ingester'
-    then 'label_name=~"ingester.*"'
-    else 'label_name="%s"' % containerName,
+    'persistentvolumeclaim=~"%s"' % containerName,
 
   goHeapInUsePanel(title, jobName)::
     $.panel(title) +
@@ -470,32 +466,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
       { yaxes: $.yaxes('percentunit') }
     ),
 
-  filterNodeDiskContainer(containerName)::
+  nodeDiskContainerBytesTotal(containerName, op)::
     |||
-      ignoring(%s) group_right() (
-        label_replace(
-          count by(
-            %s,
-            %s,
-            device
-          )
-          (
-            container_fs_writes_bytes_total{
-              %s,
-              container="%s",
-              device!~".*sda.*"
-            }
-          ),
-          "device",
-          "$1",
-          "device",
-          "/dev/(.*)"
-        ) * 0
-      )
+      container_fs_%s_bytes_total{
+        %s,
+        container="%s",
+        device!~".*sda.*|.*nvme0.*"
+      }
     ||| % [
-      $._config.per_instance_label,
-      $._config.per_node_label,
-      $._config.per_instance_label,
+      op,
       $.namespaceMatcher(),
       containerName,
     ],

--- a/cortex-mixin/dashboards/queries.libsonnet
+++ b/cortex-mixin/dashboards/queries.libsonnet
@@ -21,7 +21,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.queryPanel('cortex_query_frontend_queue_length{%s}' % $.jobMatcher($._config.job_names.query_frontend), '{{cluster}} / {{namespace}} / {{%s}}' % $._config.per_instance_label),
       )
     )
-    .addRow(
+    .addRowIf(
+      $._config.query_scheduler_enabled,
       $.row('Query Scheduler')
       .addPanel(
         $.panel('Queue Duration') +

--- a/cortex-mixin/dashboards/reads-resources.libsonnet
+++ b/cortex-mixin/dashboards/reads-resources.libsonnet
@@ -4,7 +4,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   'cortex-reads-resources.json':
     ($.dashboard('Cortex / Reads Resources') + { uid: '2fd2cda9eea8d8af9fbc0a5960425120' })
     .addClusterSelectorTemplates(false)
-    .addRow(
+    .addRowIf(
+      $._config.cortex_gw_enabled,
       $.row('Gateway')
       .addPanel(
         $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
@@ -28,7 +29,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.query_frontend),
       )
     )
-    .addRow(
+    .addRowIf(
+      $._config.query_scheduler_enabled,
       $.row('Query Scheduler')
       .addPanel(
         $.containerCPUUsagePanel('CPU', 'query-scheduler'),
@@ -64,7 +66,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.goHeapInUsePanel('Memory (go heap inuse)', $._config.job_names.ingester),
       )
     )
-    .addRow(
+    .addRowIf(
+      $._config.ruler_enabled,
       $.row('Ruler')
       .addPanel(
         $.panel('Rules') +
@@ -77,7 +80,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerCPUUsagePanel('CPU', 'ruler'),
       )
     )
-    .addRow(
+    .addRowIf(
+      $._config.ruler_enabled,
       $.row('')
       .addPanel(
         $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
@@ -109,7 +113,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerDiskReadsPanel('Disk Reads', 'store-gateway'),
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk Space Utilization', 'store-gateway'),
+        $.containerDiskSpaceUtilization('Disk Space Utilization', $._config.instance_names.store_gateway),
       )
     ) + {
       templating+: {

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -4,7 +4,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   local config = {
     gateway_read_routes_regex: '(%s|api_prom)_api_v1_.+' % $._config.prometheus_http_prefix,
   },
-  
+
   'cortex-reads.json':
     ($.dashboard('Cortex / Reads') + { uid: '8d6ba60eccc4b6eedfa329b24b1bd339' })
     .addClusterSelectorTemplates()

--- a/cortex-mixin/dashboards/reads.libsonnet
+++ b/cortex-mixin/dashboards/reads.libsonnet
@@ -55,7 +55,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               cortex_prometheus_rule_evaluations_total{
                 %(ruler)s
               }[$__rate_interval]
-            )
+            ) or on() vector(0)
           )
         ||| % {
           queryFrontend: $.jobMatcher($._config.job_names.query_frontend),

--- a/cortex-mixin/dashboards/rollout-progress.libsonnet
+++ b/cortex-mixin/dashboards/rollout-progress.libsonnet
@@ -85,7 +85,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           { color: 'green', value: 1 },
         ], unit='percentunit', min=0, max=1) + {
           id: 1,
-          gridPos: { h: 8, w: 10, x: 0, y: 0 },
+          gridPos: { h: 10, w: 10, x: 0, y: 0 },
         },
 
         //
@@ -93,50 +93,50 @@ local utils = import 'mixin-utils/utils.libsonnet';
         //
         $.panel('Writes - 2xx') +
         $.newStatPanel(|||
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s",status_code=~"2.+"}[$__rate_interval])) /
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}[$__rate_interval]))
+          sum(rate(cortex_request_duration_seconds_count{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s",status_code=~"2.+"}[$__rate_interval])) /
+          sum(rate(cortex_request_duration_seconds_count{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}[$__rate_interval])) or on() vector(0)
         ||| % config, thresholds=[
           { color: 'green', value: null },
         ]) + {
           id: 2,
-          gridPos: { h: 4, w: 2, x: 10, y: 0 },
+          gridPos: { h: 5, w: 2, x: 10, y: 10 },
         },
 
         $.panel('Writes - 4xx') +
         $.newStatPanel(|||
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s",status_code=~"4.+"}[$__rate_interval])) /
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}[$__rate_interval]))
+          sum(rate(cortex_request_duration_seconds_count{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s",status_code=~"4.+"}[$__rate_interval])) /
+          sum(rate(cortex_request_duration_seconds_count{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}[$__rate_interval])) or on() vector(0)
         ||| % config, thresholds=[
           { color: 'green', value: null },
           { color: 'orange', value: 0.2 },
           { color: 'red', value: 0.5 },
         ]) + {
           id: 3,
-          gridPos: { h: 4, w: 2, x: 12, y: 0 },
+          gridPos: { h: 5, w: 2, x: 12, y: 10 },
         },
 
         $.panel('Writes - 5xx') +
         $.newStatPanel(|||
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s",status_code=~"5.+"}[$__rate_interval])) /
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}[$__rate_interval]))
+          sum(rate(cortex_request_duration_seconds_count{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s",status_code=~"5.+"}[$__rate_interval])) /
+          sum(rate(cortex_request_duration_seconds_count{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}[$__rate_interval])) or on() vector(0)
         ||| % config, thresholds=[
           { color: 'green', value: null },
           { color: 'red', value: 0.01 },
         ]) + {
           id: 4,
-          gridPos: { h: 4, w: 2, x: 14, y: 0 },
+          gridPos: { h: 5, w: 2, x: 14, y: 10 },
         },
 
         $.panel('Writes 99th Latency') +
         $.newStatPanel(|||
-          histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}))
+          histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}))
         ||| % config, unit='s', thresholds=[
           { color: 'green', value: null },
           { color: 'orange', value: 0.2 },
           { color: 'red', value: 0.5 },
         ]) + {
           id: 5,
-          gridPos: { h: 4, w: 8, x: 16, y: 0 },
+          gridPos: { h: 5, w: 8, x: 16, y: 10 },
         },
 
         //
@@ -144,50 +144,50 @@ local utils = import 'mixin-utils/utils.libsonnet';
         //
         $.panel('Reads - 2xx') +
         $.newStatPanel(|||
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s",status_code=~"2.+"}[$__rate_interval])) /
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}[$__rate_interval]))
+          sum(rate(cortex_request_duration_seconds_count{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s",status_code=~"2.+"}[$__rate_interval])) /
+          sum(rate(cortex_request_duration_seconds_count{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}[$__rate_interval])) or on() vector(0)
         ||| % config, thresholds=[
           { color: 'green', value: null },
         ]) + {
           id: 6,
-          gridPos: { h: 4, w: 2, x: 10, y: 4 },
+          gridPos: { h: 5, w: 2, x: 10, y: 15 },
         },
 
         $.panel('Reads - 4xx') +
         $.newStatPanel(|||
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s",status_code=~"4.+"}[$__rate_interval])) /
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}[$__rate_interval]))
+          sum(rate(cortex_request_duration_seconds_count{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s",status_code=~"4.+"}[$__rate_interval])) /
+          sum(rate(cortex_request_duration_seconds_count{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}[$__rate_interval])) or on() vector(0)
         ||| % config, thresholds=[
           { color: 'green', value: null },
           { color: 'orange', value: 0.01 },
           { color: 'red', value: 0.05 },
         ]) + {
           id: 7,
-          gridPos: { h: 4, w: 2, x: 12, y: 4 },
+          gridPos: { h: 5, w: 2, x: 12, y: 15 },
         },
 
         $.panel('Reads - 5xx') +
         $.newStatPanel(|||
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s",status_code=~"5.+"}[$__rate_interval])) /
-          sum(rate(cortex_request_duration_seconds_count{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}[$__rate_interval]))
+          sum(rate(cortex_request_duration_seconds_count{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s",status_code=~"5.+"}[$__rate_interval])) /
+          sum(rate(cortex_request_duration_seconds_count{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}[$__rate_interval])) or on() vector(0)
         ||| % config, thresholds=[
           { color: 'green', value: null },
           { color: 'red', value: 0.01 },
         ]) + {
           id: 8,
-          gridPos: { h: 4, w: 2, x: 14, y: 4 },
+          gridPos: { h: 5, w: 2, x: 14, y: 15 },
         },
 
         $.panel('Reads 99th Latency') +
         $.newStatPanel(|||
-          histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}))
+          histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}))
         ||| % config, unit='s', thresholds=[
           { color: 'green', value: null },
           { color: 'orange', value: 1 },
           { color: 'red', value: 2.5 },
         ]) + {
           id: 9,
-          gridPos: { h: 4, w: 8, x: 16, y: 4 },
+          gridPos: { h: 5, w: 8, x: 16, y: 15 },
         },
 
         //
@@ -220,7 +220,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             },
           },
           id: 10,
-          gridPos: { h: 8, w: 10, x: 0, y: 8 },
+          gridPos: { h: 10, w: 6, x: 10, y: 0 },
         },
 
         //
@@ -266,7 +266,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             {
               // Hide time.
               id: 'organize',
-              options: { excludeByName: { Time: true } },
+              options: { excludeByName: { Time: true }, indexByName: { Time: 0, container: 1 } },
             },
             {
               // Sort by container.
@@ -276,7 +276,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ],
 
           id: 11,
-          gridPos: { h: 8, w: 6, x: 10, y: 8 },
+          gridPos: { h: 10, w: 10, x: 0, y: 10 },
         },
 
         //
@@ -285,15 +285,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.panel('Latency vs 24h ago') +
         $.queryPanel([|||
           1 - (
-            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"} offset 24h))[1h:])
+            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s"} offset 24h))[1h:])
             /
-            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(gateway_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}))[1h:])
+            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(writes_job_matcher)s, route=~"%(gateway_write_routes_regex)s"}))[1h:])
           )
         ||| % config, |||
           1 - (
-            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s"} offset 24h))[1h:])
+            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s"} offset 24h))[1h:])
             /
-            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(gateway_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}))[1h:])
+            avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(reads_job_matcher)s, route=~"%(gateway_read_routes_regex)s"}))[1h:])
           )
         ||| % config], ['writes', 'reads']) + {
           yaxes: $.yaxes({
@@ -302,7 +302,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           }),
 
           id: 12,
-          gridPos: { h: 8, w: 8, x: 16, y: 8 },
+          gridPos: { h: 10, w: 8, x: 16, y: 0 },
         },
       ],
 

--- a/cortex-mixin/dashboards/rollout-progress.libsonnet
+++ b/cortex-mixin/dashboards/rollout-progress.libsonnet
@@ -4,9 +4,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
   local config = {
     namespace_matcher: $.namespaceMatcher(),
     gateway_job_matcher: $.jobMatcher($._config.job_names.gateway),
+    writes_job_matcher: $.jobMatcher($._config.job_names.distributor),
+    reads_job_matcher: $.jobMatcher($._config.job_names.querier),
     gateway_write_routes_regex: 'api_(v1|prom)_push',
     gateway_read_routes_regex: '(prometheus|api_prom)_api_v1_.+',
-    all_services_regex: std.join('|', ['cortex-gw', 'distributor', 'ingester.*', 'query-frontend.*', 'query-scheduler.*', 'querier.*', 'compactor', 'store-gateway', 'ruler', 'alertmanager']),
+    all_services_regex: std.join('|', ['cortex-gw', '.*distributor.*', '.*ingester.*', '.*query-frontend.*', '.*query-scheduler.*', '.*querier.*', '.*compactor.*', '.*store-gateway.*', '.*ruler.*', '.*alertmanager.*', '.*memcached.*']),
   },
 
   'cortex-rollout-progress.json':
@@ -235,7 +237,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 count by(container, version) (
                   label_replace(
                     kube_pod_container_info{%(namespace_matcher)s,container=~"%(all_services_regex)s"},
-                    "version", "$1", "image", ".*:(.+)-.*"
+                    "version", "$1", "image", ".*:(.+)"
                   )
                 )
               ||| % config,

--- a/cortex-mixin/dashboards/rollout-progress.libsonnet
+++ b/cortex-mixin/dashboards/rollout-progress.libsonnet
@@ -7,7 +7,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     writes_job_matcher: $.jobMatcher($._config.job_names.distributor),
     reads_job_matcher: $.jobMatcher($._config.job_names.querier),
     gateway_write_routes_regex: 'api_(v1|prom)_push',
-    gateway_read_routes_regex: '(prometheus|api_prom)_api_v1_.+',
+    gateway_read_routes_regex: '(%s|api_prom)_api_v1_.+' % $._config.prometheus_http_prefix,
     all_services_regex: std.join('|', ['cortex-gw', '.*distributor.*', '.*ingester.*', '.*query-frontend.*', '.*query-scheduler.*', '.*querier.*', '.*compactor.*', '.*store-gateway.*', '.*ruler.*', '.*alertmanager.*', '.*memcached.*']),
   },
 

--- a/cortex-mixin/dashboards/scaling.libsonnet
+++ b/cortex-mixin/dashboards/scaling.libsonnet
@@ -1,7 +1,6 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
 (import 'dashboard-utils.libsonnet') {
-
   'cortex-scaling.json':
     ($.dashboard('Cortex / Scaling') + { uid: '88c041017b96856c9176e07cf557bdcf' })
     .addClusterSelectorTemplates()
@@ -42,18 +41,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.tablePanel([
           |||
             sort_desc(
-              cluster_namespace_deployment_reason:required_replicas:count{cluster=~"$cluster", namespace=~"$namespace"}
+              cluster_namespace_deployment_reason:required_replicas:count{%(namespace_matcher)s}
                 > ignoring(reason) group_left
-              cluster_namespace_deployment:actual_replicas:count{cluster=~"$cluster", namespace=~"$namespace"}
+              cluster_namespace_deployment:actual_replicas:count{%(namespace_matcher)s}
             )
-          |||,
+          ||| % {
+            namespace_matcher: $.namespaceMatcher(),
+          },
         ], {
           __name__: { alias: 'Cluster', type: 'hidden' },
           cluster: { alias: 'Cluster' },
           namespace: { alias: 'Namespace' },
           deployment: { alias: 'Service' },
           reason: { alias: 'Reason' },
-          Value: { alias: 'Required Replicas', decimals: 0 },
+          'Value #A': { alias: 'Required Replicas', decimals: 0 },
         })
       )
     ),

--- a/cortex-mixin/dashboards/writes-resources.libsonnet
+++ b/cortex-mixin/dashboards/writes-resources.libsonnet
@@ -4,7 +4,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   'cortex-writes-resources.json':
     ($.dashboard('Cortex / Writes Resources') + { uid: 'c0464f0d8bd026f776c9006b0591bb0b' })
     .addClusterSelectorTemplates(false)
-    .addRow(
+    .addRowIf(
+      $._config.cortex_gw_enabled,
       $.row('Gateway')
       .addPanel(
         $.containerCPUUsagePanel('CPU', $._config.job_names.gateway),
@@ -62,7 +63,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         $.containerDiskReadsPanel('Disk Reads', 'ingester')
       )
       .addPanel(
-        $.containerDiskSpaceUtilization('Disk Space Utilization', 'ingester'),
+        $.containerDiskSpaceUtilization('Disk Space Utilization', $._config.instance_names.ingester),
       )
     )
     + {

--- a/cortex-mixin/dashboards/writes.libsonnet
+++ b/cortex-mixin/dashboards/writes.libsonnet
@@ -61,10 +61,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
       )
       .addPanel(
         $.panel('Requests / sec') +
-        $.statPanel('sum(rate(cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}[5m]))' % $.jobMatcher($._config.job_names.gateway), format='reqps')
+        $.statPanel('sum(rate(cortex_request_duration_seconds_count{%s, route=~"api_(v1|prom)_push"}[5m]))' % $.jobMatcher($._config.job_names.distributor), format='reqps')
       )
     )
-    .addRow(
+    .addRowIf(
+      $._config.cortex_gw_enabled,
       $.row('Gateway')
       .addPanel(
         $.panel('Requests / sec') +


### PR DESCRIPTION
**What this PR does**:

Update cortex-mixin to support Helm chart deployment and produce usable dashboards. List of issues fixed by this change:
- support disabling cortex-gw, query scheduler and ruler panels
- generalize instance names to also match Helm chart deployments
- remove cluster from namespace matcher to cope with metrics outside Cortex service that don't have a cluster label
- fix disk panels to display correct written byte metrics
- support custom Prometheus http prefix
- display read/write metrics from Cortex distributor/querier instead of cortex-gw
- rearrange panels in rollout dashboard to make better sense of the metrics shown

Caveat: 
- I tested dashboards with Helm chart deployments but since that uses opensource Cortex image I could not test the dashboards when cortex-gw component is enabled.  

**Which issue(s) this PR fixes**:
Fixes #361

**Checklist**
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
